### PR TITLE
Map Kafka Topic Name to Pulsar (replace '.' with '/')

### DIFF
--- a/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/meta/Store.java
@@ -52,7 +52,7 @@ public interface Store {
    *  2. No double dashes
    */
 
-  Pattern storeNamePattern = Pattern.compile("^[a-zA-Z0-9_-]+$");
+  Pattern storeNamePattern = Pattern.compile("^[a-zA-Z0-9._-]+$");
 
   static boolean isValidStoreName(String name) {
     Matcher matcher = storeNamePattern.matcher(name);


### PR DESCRIPTION
Motivation:
in Pulsar we use topics in this form: tenant/namespace/topic.
It would be great to allow Venice users to store the data in their tenants topics:
- allow to leverage Pulsar resources isolation
- security: push jobs can use credentials allowed to connect only to your own topics


Contents:
- replace '.' with '/' while dealing with Kafka (consumer, producer, admin)

A storeName `tenant.namespace.storename `will use topics like` tenant/namespace/storename_v1`


TODOs:
- Tests, tests, tests.... (with one big issue, that Kafka doesn't allow you to use '/', so we have to start Pulsar instead of Kafka

Problems:
- the are APIs that require to list all the topics in Kafka, this is kind of a problem as you cannot list all the topics in all the tenants. List topics returns only the topics in the "default" namespaces
