### PR TITLE
[controller][admin-tool] Implement JWT Authentication on the Controller Service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,10 @@ ext.libraries = [
     xerces: 'xerces:xercesImpl:2.9.1',
     zkclient: 'com.101tec:zkclient:0.7', // For Kafka AdminUtils
     zookeeper: 'org.apache.zookeeper:zookeeper:3.5.9',
-    zstd: 'com.github.luben:zstd-jni:1.5.2-3'
+    zstd: 'com.github.luben:zstd-jni:1.5.2-3',
+    jjwtapi: 'io.jsonwebtoken:jjwt-api:0.11.2',
+    jjwtimpl: 'io.jsonwebtoken:jjwt-impl:0.11.2',
+    jjwtjackson: 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 ]
 
 group = 'com.linkedin.venice'

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -138,7 +138,6 @@ public class AdminTool {
   private static final String SUCCESS = "success";
 
   private static final PubSubTopicRepository PUB_SUB_TOPIC_REPOSITORY = new PubSubTopicRepository();
-
   private static ControllerClient controllerClient;
   private static Optional<SSLFactory> sslFactory = Optional.empty();
   private static final Map<String, Map<String, ControllerClient>> clusterControllerClientPerColoMap = new HashMap<>();
@@ -196,6 +195,10 @@ public class AdminTool {
 
       if (cmd.hasOption(Arg.FLAT_JSON.toString())) {
         jsonWriter = ObjectMapperFactory.getInstance().writer();
+      }
+
+      if (Arrays.asList(foundCommand.getOptionalArgs()).contains(Arg.TOKEN)) {
+        controllerClient.addHeader("Authorization", "Bearer " + getOptionalArgument(cmd, Arg.TOKEN, ""));
       }
 
       switch (foundCommand) {

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -173,6 +173,8 @@ public class AdminTool {
         LogConfigurator.disableLog();
       }
 
+      String token = getOptionalArgument(cmd, Arg.TOKEN, "");
+
       if (Arrays.asList(foundCommand.getRequiredArgs()).contains(Arg.URL)
           && Arrays.asList(foundCommand.getRequiredArgs()).contains(Arg.CLUSTER)) {
         veniceUrl = getRequiredArgument(cmd, Arg.URL);
@@ -182,7 +184,7 @@ public class AdminTool {
          * SSL config file is not mandatory now; build the controller with SSL config if provided.
          */
         buildSslFactory(cmd);
-        controllerClient = ControllerClient.constructClusterControllerClient(clusterName, veniceUrl, sslFactory);
+        controllerClient = ControllerClient.constructClusterControllerClient(clusterName, veniceUrl, sslFactory, token);
       }
 
       if (Arrays.asList(foundCommand.getRequiredArgs()).contains(Arg.CLUSTER_SRC)) {
@@ -195,10 +197,6 @@ public class AdminTool {
 
       if (cmd.hasOption(Arg.FLAT_JSON.toString())) {
         jsonWriter = ObjectMapperFactory.getInstance().writer();
-      }
-
-      if (Arrays.asList(foundCommand.getOptionalArgs()).contains(Arg.TOKEN)) {
-        controllerClient.addHeader("Authorization", "Bearer " + getOptionalArgument(cmd, Arg.TOKEN, ""));
       }
 
       switch (foundCommand) {
@@ -2436,8 +2434,9 @@ public class AdminTool {
       if (storeName.isEmpty()) {
         throw new VeniceException("Please either provide a valid topic name or a cluster name.");
       }
+      String token = getOptionalArgument(cmd, Arg.TOKEN);
       D2ServiceDiscoveryResponse clusterDiscovery =
-          ControllerClient.discoverCluster(veniceControllerUrls, storeName, sslFactory, 3);
+          ControllerClient.discoverCluster(veniceControllerUrls, storeName, sslFactory, 3, token);
       clusterName = clusterDiscovery.getCluster();
     }
 

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Arg.java
@@ -11,6 +11,7 @@ public enum Arg {
   URL("url", "u", true, "Venice url, eg. http://localhost:1689  This can be a router or a controller"),
   VENICE_ZOOKEEPER_URL("venice-zookeeper-url", "vzu", true, "Venice Zookeeper url, eg. localhost:2622"),
   CLUSTER("cluster", "c", true, "Name of Venice cluster"),
+  TOKEN("token", "t", true, "Authentication Token for JWT authentication"),
   CLUSTER_SRC("cluster-src", "cs", true, "Store migration original Venice cluster name"),
   CLUSTER_DEST("cluster-dest", "cd", true, "Store migration destination Venice cluster name"),
   STORE("store", "s", true, "Name of Venice store"), STORES("stores", "sts", true, "Name of a group of Venice stores"),

--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/Command.java
@@ -96,6 +96,7 @@ import static com.linkedin.venice.Arg.STORE_SIZE;
 import static com.linkedin.venice.Arg.STORE_TYPE;
 import static com.linkedin.venice.Arg.STORE_VIEW_CONFIGS;
 import static com.linkedin.venice.Arg.SYSTEM_STORE_TYPE;
+import static com.linkedin.venice.Arg.TOKEN;
 import static com.linkedin.venice.Arg.URL;
 import static com.linkedin.venice.Arg.VALUE_SCHEMA;
 import static com.linkedin.venice.Arg.VALUE_SCHEMA_ID;
@@ -460,14 +461,17 @@ public enum Command {
   private final Arg[] optionalArgs;
 
   Command(String argName, String description, Arg[] requiredArgs) {
-    this(argName, description, requiredArgs, new Arg[] {});
+    this(argName, description, requiredArgs, new Arg[] { TOKEN });
   }
 
   Command(String argName, String description, Arg[] requiredArgs, Arg[] optionalArgs) {
     this.commandName = argName;
     this.description = description;
     this.requiredArgs = requiredArgs;
-    this.optionalArgs = optionalArgs;
+    Arg[] withToken = new Arg[optionalArgs.length + 1];
+    System.arraycopy(optionalArgs, 0, withToken, 0, optionalArgs.length);
+    withToken[withToken.length - 1] = TOKEN;
+    this.optionalArgs = withToken;
   }
 
   @Override

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/CommonConfigKeys.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/CommonConfigKeys.java
@@ -38,4 +38,9 @@ public class CommonConfigKeys {
    *    (Container 25.2.15)
    */
   public static final String SSL_FACTORY_CLASS_NAME = "ssl.factory.class.name";
+
+  /**
+   * This configuration is the JWT token to use to connect to the backend.
+   */
+  public static final String AUTHENTICATION_TOKEN = "authentication.token";
 }

--- a/internal/venice-common/build.gradle
+++ b/internal/venice-common/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
   api project(':internal:venice-client-common')
+  api libraries.jjwtapi
 
   implementation (libraries.avro) {
     exclude group: 'org.jboss.netty' // older version of netty3 causes transitive conflicts with the router
@@ -40,6 +41,10 @@ dependencies {
   implementation libraries.kafkaClients // TODO: Get rid of Kafka dependency in venice-common
   implementation libraries.oss
   implementation libraries.tehuti
+
+  implementation libraries.jjwtimpl // JWT authentication service
+  implementation libraries.jjwtjackson // JWT authentication service
+
   // It's necessary to pull in the most recent version of zkclient explicitly, otherwise Helix won't have it...
   implementation libraries.zkclient
   implementation libraries.zookeeper // TODO: Get rid of ZK dependency in venice-common

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationService.java
@@ -1,0 +1,30 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.Closeable;
+import java.security.cert.X509Certificate;
+
+
+/**
+ * Performs authentication.
+ */
+public interface AuthenticationService extends Closeable {
+  default void initialise(VeniceProperties veniceProperties) throws Exception {
+  }
+
+  @Override
+  default void close() {
+  }
+
+  default Principal getPrincipalFromHttpRequest(HttpRequestAccessor requestAccessor) {
+    return null;
+  }
+
+  interface HttpRequestAccessor {
+    String getHeader(String headerName);
+
+    X509Certificate getCertificate();
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationServiceUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationServiceUtils.java
@@ -1,0 +1,34 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public abstract class AuthenticationServiceUtils {
+  private static final Logger LOGGER = LogManager.getLogger(AuthenticationServiceUtils.class);
+
+  private AuthenticationServiceUtils() {
+  }
+
+  public static Optional<AuthenticationService> buildAuthenticationService(VeniceProperties veniceProperties) {
+    String className = veniceProperties.getString("authentication.service.class", "");
+    if (className.isEmpty()) {
+      return Optional.empty();
+    }
+    LOGGER.info("Building authentication service: {}", className);
+    try {
+      AuthenticationService authenticationService =
+          Class.forName(className, false, AuthenticationService.class.getClassLoader())
+              .asSubclass(AuthenticationService.class)
+              .getConstructor()
+              .newInstance();
+      authenticationService.initialise(veniceProperties);
+      return Optional.of(authenticationService);
+    } catch (Exception ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/LogOnlyAuthenticationService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/LogOnlyAuthenticationService.java
@@ -1,0 +1,28 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.utils.VeniceProperties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class LogOnlyAuthenticationService implements AuthenticationService {
+  private static final Logger LOGGER = LogManager.getLogger(LogOnlyAuthenticationService.class);
+
+  @Override
+  public void initialise(VeniceProperties veniceProperties) throws Exception {
+    LOGGER.info("initialise {}", veniceProperties);
+  }
+
+  @Override
+  public void close() {
+    LOGGER.info("close");
+  }
+
+  @Override
+  public Principal getPrincipalFromHttpRequest(HttpRequestAccessor requestAccessor) {
+    LOGGER.info("getPrincipalFromHttpRequest {}", requestAccessor);
+    return null;
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/AuthenticationProviderToken.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/AuthenticationProviderToken.java
@@ -1,0 +1,203 @@
+package com.linkedin.venice.authentication.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.RequiredTypeException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.DecodingException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Paths;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.List;
+import javax.crypto.SecretKey;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+
+class AuthenticationProviderToken {
+  public static final class AuthenticationException extends Exception {
+    public AuthenticationException(String message) {
+      super(message);
+    }
+  }
+
+  private final JwtParser parser;
+  private final String roleClaim;
+  private final SignatureAlgorithm publicKeyAlg;
+  private final String audienceClaim;
+  private final String audience;
+
+  public AuthenticationProviderToken(TokenProperties tokenProperties) throws IOException, IllegalArgumentException {
+    this.publicKeyAlg = getPublicKeyAlgType(tokenProperties);
+    parser = Jwts.parserBuilder()
+        .setSigningKeyResolver(
+            new JwksUriSigningKeyResolver(
+                publicKeyAlg.getValue(),
+                tokenProperties.getJwksHostsAllowlist(),
+                getValidationKeyFromConfig(tokenProperties)))
+        .build();
+    this.roleClaim = getTokenRoleClaim(tokenProperties);
+    this.audienceClaim = getTokenAudienceClaim(tokenProperties);
+    this.audience = getTokenAudience(tokenProperties);
+
+    if (this.audienceClaim != null && this.audience == null) {
+      throw new IllegalArgumentException(
+          "Token Audience Claim [" + this.audienceClaim + "] configured, but Audience stands for this broker not.");
+    }
+  }
+
+  public String authenticate(String token) throws AuthenticationException {
+    final Jwt<?, Claims> jwt = authenticateToken(token);
+    return getPrincipal(jwt);
+  }
+
+  private Jwt<?, Claims> authenticateToken(final String token) throws AuthenticationException {
+    try {
+      Jwt<?, Claims> jwt = parser.parseClaimsJws(token);
+      if (this.audienceClaim != null) {
+        Object object = ((Claims) jwt.getBody()).get(this.audienceClaim);
+        if (object == null) {
+          throw new JwtException("Found null Audience in token, for claimed field: " + this.audienceClaim);
+        }
+
+        if (object instanceof List) {
+          List<String> audiences = (List) object;
+          if (audiences.stream().noneMatch(audienceInToken -> {
+            return audienceInToken.equals(this.audience);
+          })) {
+            throw new AuthenticationException(
+                "Audiences in token: [" + String.join(", ", audiences) + "] not contains this audience: "
+                    + this.audience);
+          }
+        } else {
+          if (!(object instanceof String)) {
+            throw new AuthenticationException("Audiences in token is not in expected format: " + object);
+          }
+
+          if (!object.equals(this.audience)) {
+            throw new AuthenticationException(
+                "Audiences in token: [" + object + "] not contains this audience: " + this.audience);
+          }
+        }
+      }
+      return jwt;
+    } catch (JwtException ex) {
+      throw new AuthenticationException("Failed to authentication token: " + ex.getMessage());
+    }
+  }
+
+  private String getPrincipal(Jwt<?, Claims> jwt) {
+    try {
+      return jwt.getBody().get(this.roleClaim, String.class);
+    } catch (RequiredTypeException var4) {
+      List list = (jwt.getBody()).get(this.roleClaim, List.class);
+      return list != null && !list.isEmpty() && list.get(0) instanceof String ? (String) list.get(0) : null;
+    }
+  }
+
+  private Key getValidationKeyFromConfig(TokenProperties tokenProperties) throws IOException {
+    String tokenSecretKey = tokenProperties.getSecretKey();
+    String tokenPublicKey = tokenProperties.getPublicKey();
+    byte[] validationKey;
+    if (StringUtils.isNotBlank(tokenSecretKey)) {
+      validationKey = readKeyFromUrl(tokenSecretKey);
+      return decodeSecretKey(validationKey);
+    } else if (StringUtils.isNotBlank(tokenPublicKey)) {
+      validationKey = readKeyFromUrl(tokenPublicKey);
+      return decodePublicKey(validationKey, this.publicKeyAlg);
+    }
+    return null;
+  }
+
+  private static byte[] readKeyFromUrl(String keyConfUrl) throws IOException {
+    if (!keyConfUrl.startsWith("data:") && !keyConfUrl.startsWith("file:")) {
+      if (Files.exists(Paths.get(keyConfUrl), new LinkOption[0])) {
+        return Files.readAllBytes(Paths.get(keyConfUrl));
+      } else if (Base64.isBase64(keyConfUrl.getBytes())) {
+        try {
+          return (byte[]) Decoders.BASE64.decode(keyConfUrl);
+        } catch (DecodingException var3) {
+          String msg = "Illegal base64 character or Key file " + keyConfUrl + " doesn't exist";
+          throw new IOException(msg, var3);
+        }
+      } else {
+        String msg = "Secret/Public Key file " + keyConfUrl + " doesn't exist";
+        throw new IllegalArgumentException(msg);
+      }
+    } else {
+      try {
+        return IOUtils.toByteArray(new URL(keyConfUrl));
+      } catch (IOException var4) {
+        throw var4;
+      } catch (Exception var5) {
+        throw new IOException(var5);
+      }
+    }
+  }
+
+  private static SecretKey decodeSecretKey(byte[] secretKey) {
+    return Keys.hmacShaKeyFor(secretKey);
+  }
+
+  private String getTokenRoleClaim(TokenProperties tokenProperties) throws IOException {
+    String tokenAuthClaim = tokenProperties.getAuthClaim();
+    return StringUtils.isNotBlank(tokenAuthClaim) ? tokenAuthClaim : "sub";
+  }
+
+  private SignatureAlgorithm getPublicKeyAlgType(TokenProperties tokenProperties) throws IllegalArgumentException {
+    String tokenPublicAlg = tokenProperties.getPublicAlg();
+    if (StringUtils.isNotBlank(tokenPublicAlg)) {
+      try {
+        return SignatureAlgorithm.forName(tokenPublicAlg);
+      } catch (SignatureException var4) {
+        throw new IllegalArgumentException("invalid algorithm provided " + tokenPublicAlg, var4);
+      }
+    } else {
+      return SignatureAlgorithm.RS256;
+    }
+  }
+
+  private static PublicKey decodePublicKey(byte[] key, SignatureAlgorithm algType) throws IOException {
+    try {
+      X509EncodedKeySpec spec = new X509EncodedKeySpec(key);
+      KeyFactory kf = KeyFactory.getInstance(keyTypeForSignatureAlgorithm(algType));
+      return kf.generatePublic(spec);
+    } catch (Exception var4) {
+      throw new IOException("Failed to decode public key", var4);
+    }
+  }
+
+  private static String keyTypeForSignatureAlgorithm(SignatureAlgorithm alg) {
+    if (alg.getFamilyName().equals("RSA")) {
+      return "RSA";
+    } else if (alg.getFamilyName().equals("ECDSA")) {
+      return "EC";
+    } else {
+      String msg = "The " + alg.name() + " algorithm does not support Key Pairs.";
+      throw new IllegalArgumentException(msg);
+    }
+  }
+
+  private String getTokenAudienceClaim(TokenProperties tokenProperties) throws IllegalArgumentException {
+    String tokenAudienceClaim = tokenProperties.getAudienceClaim();
+    return StringUtils.isNotBlank(tokenAudienceClaim) ? tokenAudienceClaim : null;
+  }
+
+  private String getTokenAudience(TokenProperties tokenProperties) throws IllegalArgumentException {
+    String tokenAudience = tokenProperties.getAudience();
+    return StringUtils.isNotBlank(tokenAudience) ? tokenAudience : null;
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/JwksUriSigningKeyResolver.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/JwksUriSigningKeyResolver.java
@@ -1,0 +1,143 @@
+package com.linkedin.venice.authentication.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.SigningKeyResolver;
+import io.jsonwebtoken.io.Decoders;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URL;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class JwksUriSigningKeyResolver implements SigningKeyResolver {
+  private static final Logger log = LogManager.getLogger(JwksUriSigningKeyResolver.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final String algorithm;
+  private final Pattern hostsAllowlist;
+  private final Key fallbackKey;
+  private volatile Map<String, Key> keyMap = new ConcurrentHashMap<>();
+
+  public JwksUriSigningKeyResolver(String algorithm, String hostsAllowlist, Key fallbackKey) {
+    this.algorithm = algorithm;
+    if (StringUtils.isBlank(hostsAllowlist)) {
+      this.hostsAllowlist = null;
+    } else {
+      this.hostsAllowlist = Pattern.compile(hostsAllowlist);
+    }
+    this.fallbackKey = fallbackKey;
+  }
+
+  @Override
+  public Key resolveSigningKey(JwsHeader header, Claims claims) {
+    final String jwksUri = (String) claims.get("jwks_uri");
+    if (jwksUri == null) {
+      return fallbackKey;
+    }
+    return getKey(jwksUri);
+  }
+
+  @Override
+  public Key resolveSigningKey(JwsHeader header, String plaintext) {
+    throw new UnsupportedOperationException();
+  }
+
+  private Key getKey(String uri) {
+    return keyMap.computeIfAbsent(uri, this::fetchKey);
+  }
+
+  private Key fetchKey(String uri) {
+    try {
+      final URL src = new URL(uri);
+      if (hostsAllowlist == null || !hostsAllowlist.matcher(src.getHost()).matches()) {
+        throw new JwtException("Untrusted hostname: '" + src.getHost() + "'");
+      }
+      final JwkKeys keys = MAPPER.readValue(src, JwkKeys.class);
+      for (JwkKey key: keys.getKeys()) {
+        if (!algorithm.equals(key.getAlg())) {
+          continue;
+        }
+        BigInteger modulus = base64ToBigInteger(key.getN());
+        BigInteger exponent = base64ToBigInteger(key.getE());
+        RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(modulus, exponent);
+        try {
+          KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+          return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+          throw new IllegalStateException("Failed to parse public key");
+        }
+      }
+      throw new JwtException("No valid keys found from URL: " + uri);
+    } catch (IOException e) {
+      System.out.println(e);
+      log.error("Failed to fetch keys from URL: {}", uri, e);
+      throw new JwtException("Failed to fetch keys from URL: " + uri, e);
+    }
+  }
+
+  private static class JwkKeys {
+    private final List<JwkKey> keys;
+
+    public JwkKeys(List<JwkKey> keys) {
+      this.keys = keys;
+    }
+
+    public List<JwkKey> getKeys() {
+      return keys;
+    }
+  }
+
+  private static class JwkKey {
+    private final String alg;
+    private final String e;
+    private final String kid;
+    private final String kty;
+    private final String n;
+
+    public JwkKey(String alg, String e, String kid, String kty, String n) {
+      this.alg = alg;
+      this.e = e;
+      this.kid = kid;
+      this.kty = kty;
+      this.n = n;
+    }
+
+    public String getAlg() {
+      return alg;
+    }
+
+    public String getE() {
+      return e;
+    }
+
+    public String getKid() {
+      return kid;
+    }
+
+    public String getKty() {
+      return kty;
+    }
+
+    public String getN() {
+      return n;
+    }
+  }
+
+  private BigInteger base64ToBigInteger(String value) {
+    return new BigInteger(1, Decoders.BASE64URL.decode(value));
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/TokenAuthenticationService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/TokenAuthenticationService.java
@@ -1,0 +1,62 @@
+package com.linkedin.venice.authentication.jwt;
+
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.utils.VeniceProperties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Validates JWT tokens passed as Bearer tokens in the HTTP Authorise Request Header.
+ */
+public class TokenAuthenticationService implements AuthenticationService {
+  private static final Logger log = LogManager.getLogger(TokenAuthenticationService.class);
+  private static final String HTTP_HEADER_VALUE_PREFIX = "Bearer ";
+
+  private AuthenticationProviderToken authenticationProvider;
+
+  @Override
+  public void initialise(VeniceProperties veniceProperties) throws Exception {
+    TokenProperties tokenProperties = new TokenProperties(
+        veniceProperties.getString("authentication.jwt.secretKey", ""),
+        veniceProperties.getString("authentication.jwt.publicKey", ""),
+        veniceProperties.getString("authentication.jwt.authClaim", ""),
+        veniceProperties.getString("authentication.jwt.publicAlg", ""),
+        veniceProperties.getString("authentication.jwt.audienceClaim", ""),
+        veniceProperties.getString("authentication.jwt.audience", ""),
+        veniceProperties.getString("authentication.jwt.jwksHostsAllowlist", ""));
+    authenticationProvider = new AuthenticationProviderToken(tokenProperties);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public Principal getPrincipalFromHttpRequest(HttpRequestAccessor requestAccessor) {
+    String httpHeaderValue = requestAccessor.getHeader("Authorization");
+    String token;
+    if (httpHeaderValue == null || httpHeaderValue.length() <= HTTP_HEADER_VALUE_PREFIX.length()) {
+      log.info("No Authorization header found in request: {}", requestAccessor);
+      return null;
+    } else {
+      token = httpHeaderValue.substring(HTTP_HEADER_VALUE_PREFIX.length());
+    }
+
+    if (log.isDebugEnabled()) {
+      log.debug("Authenticating user with token: {}", token);
+    }
+    try {
+      String role = authenticationProvider.authenticate(token);
+      if (log.isDebugEnabled()) {
+        log.debug("Authenticated user: {} with role: {}", token, role);
+      }
+      return new Principal(role);
+    } catch (AuthenticationProviderToken.AuthenticationException error) {
+      log.error("Cannot authenticatate user with token: {}", token, error);
+      return null;
+    }
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/TokenProperties.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/jwt/TokenProperties.java
@@ -1,0 +1,74 @@
+package com.linkedin.venice.authentication.jwt;
+
+/**
+ * Token properties
+ * secretKey secret key when using symmetric keys or private key when using asymmetric keys
+ * publicKey public key when using asymmetric keys
+ * authClaim claim from which to extract the authentication role (default "sub")
+ * publicAlg algorithm used to sign the token (default "HS256")
+ * audienceClaim claim from which to extract the audience (default null, no audience check)
+ * audience audience to verify
+ * adminRoles list of roles that are considered as admin
+ */
+public class TokenProperties {
+  private final String secretKey;
+  private final String publicKey;
+  private final String authClaim;
+  private final String publicAlg;
+  private final String audienceClaim;
+  private final String audience;
+  private final String jwksHostsAllowlist;
+
+  public TokenProperties(
+      String secretKey,
+      String publicKey,
+      String authClaim,
+      String publicAlg,
+      String audienceClaim,
+      String audience,
+      String jwksHostsAllowlist) {
+    this.secretKey = secretKey;
+    this.publicKey = publicKey;
+    this.authClaim = authClaim;
+    this.publicAlg = publicAlg;
+    this.audienceClaim = audienceClaim;
+    this.audience = audience;
+    this.jwksHostsAllowlist = jwksHostsAllowlist;
+  }
+
+  public String getSecretKey() {
+    return secretKey;
+  }
+
+  public String getPublicKey() {
+    return publicKey;
+  }
+
+  public String getAuthClaim() {
+    return authClaim;
+  }
+
+  public String getPublicAlg() {
+    return publicAlg;
+  }
+
+  public String getAudienceClaim() {
+    return audienceClaim;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public String getJwksHostsAllowlist() {
+    return jwksHostsAllowlist;
+  }
+
+  @Override
+  public String toString() {
+    return "TokenProperties{" + "secretKey='" + secretKey + '\'' + ", publicKey='" + publicKey + '\'' + ", authClaim='"
+        + authClaim + '\'' + ", publicAlg='" + publicAlg + '\'' + ", audienceClaim='" + audienceClaim + '\''
+        + ", audience='" + audience + "', jwksHostsAllowlist='" + jwksHostsAllowlist + '\'' + '}';
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerService.java
@@ -27,8 +27,8 @@ public interface AuthorizerService {
    * Check if the principal has the permission to perform the method on the resource. Implementation should define how to handle
    * duplicate/conflicting ACE entries present for the resource and also how to handle presence of no AceEntries for a resource.
    *
-   * @param method what method is being performed.
-   * @param resource what resource the method is being performed
+   * @param method    what method is being performed.
+   * @param resource  what resource the method is being performed
    * @param principal who is performing the method on the resource.
    * @return {@code true} if principal has the permission to perform the method on the resource, otherwise return {@code false}.
    */
@@ -38,8 +38,8 @@ public interface AuthorizerService {
    * Check if the principal has the permission to perform the method on the resource. Implementation should define how to handle
    * duplicate/conflicting ACE entries present for the resource and also how to handle presence of no AceEntries for a resource.
    *
-   * @param method what method is being performed.
-   * @param resource what resource the method is being performed
+   * @param method       what method is being performed.
+   * @param resource     what resource the method is being performed
    * @param accessorCert who is performing the method on the resource.
    * @return {@code true} if principal has the permission to perform the method on the resource, otherwise return {@code false}.
    */
@@ -48,6 +48,7 @@ public interface AuthorizerService {
   /**
    * Return a list of existing AceEntries present for the given resource.
    * Implementations should return an empty AclBinding object when no acl's are present for the resource.
+   *
    * @param resource
    * @return {@link AclBinding} object containg the list of existing aceEntries. The AceEntry list may be empty if there is no existing ACL's provisioned.
    */
@@ -90,24 +91,37 @@ public interface AuthorizerService {
   /**
    * This may perform any initialization steps that may be necessary before start provisioning any ACL's for a resource. This
    * may be used to setup/allocate any metadata/context about the resource.
-   *
+   * <p>
    * This is optional to implement.
    * Implementation should mandate if this needs to be called before start provisioning any ACL's for the resource.
+   *
    * @param resource
    */
   public default void setupResource(Resource resource) {
-  };
+  }
+
+  ;
 
   /**
    * This may perform any finalization steps that may be necessary after all ACL's for a resource is deleted and the resource will
    * not be used later. This may be used to clean up any metadata/context information about the resource that was setup in
    * {@link #setupResource}.
-   *
+   * <p>
    * This is optional to implement.
    * Implementation should mandate if this needs to be called after deleting all ACL's for the resource.
+   *
    * @param resource
    */
   public default void clearResource(Resource resource) {
-  };
+  }
+
+  /**
+   * Tells whether the user is a super user or not. This is used to bypass ACL checks.
+   * @param principal
+   * @return true or false
+   */
+  public default boolean isSuperUser(Principal principal, String storeName) {
+    return false;
+  }
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerService.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.authorization;
 
+import com.linkedin.venice.utils.VeniceProperties;
+import java.io.Closeable;
 import java.security.cert.X509Certificate;
 
 
@@ -22,7 +24,14 @@ import java.security.cert.X509Certificate;
  *   {@link #clearResource(Resource)}
  * }
  */
-public interface AuthorizerService {
+public interface AuthorizerService extends Closeable {
+  /**
+   * Perform any initialization tasks.
+   * @param veniceProperties
+   */
+  public default void initialise(VeniceProperties veniceProperties) throws Exception {
+  }
+
   /**
    * Check if the principal has the permission to perform the method on the resource. Implementation should define how to handle
    * duplicate/conflicting ACE entries present for the resource and also how to handle presence of no AceEntries for a resource.
@@ -122,6 +131,10 @@ public interface AuthorizerService {
    */
   public default boolean isSuperUser(Principal principal, String storeName) {
     return false;
+  }
+
+  @Override
+  public default void close() {
   }
 
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerServiceUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerServiceUtils.java
@@ -1,0 +1,33 @@
+package com.linkedin.venice.authorization;
+
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public abstract class AuthorizerServiceUtils {
+  private static final Logger LOGGER = LogManager.getLogger(AuthorizerServiceUtils.class);
+
+  private AuthorizerServiceUtils() {
+  }
+
+  public static Optional<AuthorizerService> buildAuthorizerService(VeniceProperties veniceProperties) {
+    String className = veniceProperties.getString("authorizer.service.class", "");
+    if (className.isEmpty()) {
+      return Optional.empty();
+    }
+    LOGGER.info("Building authorizer service: {}", className);
+    try {
+      AuthorizerService authorizerService = Class.forName(className, false, AuthorizerService.class.getClassLoader())
+          .asSubclass(AuthorizerService.class)
+          .getConstructor()
+          .newInstance();
+      authorizerService.initialise(veniceProperties);
+      return Optional.of(authorizerService);
+    } catch (Exception ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authorization/SimpleAuthorizerService.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authorization/SimpleAuthorizerService.java
@@ -1,0 +1,56 @@
+package com.linkedin.venice.authorization;
+
+import java.security.cert.X509Certificate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * A very simple AuthorizerService that requires that the user is authenticated.
+ * In that case the user in allowed to do anything.
+ */
+public class SimpleAuthorizerService implements AuthorizerService {
+  private static final Logger LOGGER = LogManager.getLogger(SimpleAuthorizerService.class);
+
+  @Override
+  public boolean canAccess(Method method, Resource resource, Principal principal) {
+    boolean result = principal != null;
+    LOGGER.info("canAccess {} {} {} -> {}", method, resource, principal, result);
+    return result;
+  }
+
+  @Override
+  public boolean canAccess(Method method, Resource resource, X509Certificate accessorCert) {
+    boolean result = accessorCert != null;
+    LOGGER.info("canAccess {} {} {} -> {}", method, resource, accessorCert, result);
+    return result;
+  }
+
+  @Override
+  public boolean isSuperUser(Principal principal, String storeName) {
+    boolean result = principal != null;
+    LOGGER.info("isSuperUser {} {} -> {}", principal, storeName, result);
+    return result;
+  }
+
+  @Override
+  public AclBinding describeAcls(Resource resource) {
+    return new AclBinding(resource);
+  }
+
+  @Override
+  public void setAcls(AclBinding aclBinding) {
+  }
+
+  @Override
+  public void clearAcls(Resource resource) {
+  }
+
+  @Override
+  public void addAce(Resource resource, AceEntry aceEntry) {
+  }
+
+  @Override
+  public void removeAce(Resource resource, AceEntry aceEntry) {
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClient.java
@@ -89,10 +89,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -111,26 +109,30 @@ public class ControllerClient implements Closeable {
   private static final int QUERY_JOB_STATUS_TIMEOUT = 60 * Time.MS_PER_SECOND;
   private static final int DEFAULT_REQUEST_TIMEOUT_MS = 600 * Time.MS_PER_SECOND;
   private final Optional<SSLFactory> sslFactory;
+  private final String token;
   private final String clusterName;
   private final VeniceJsonSerializer<Version> versionVeniceJsonSerializer = new VeniceJsonSerializer<>(Version.class);
   private String leaderControllerUrl;
   private final List<String> controllerDiscoveryUrls;
 
-  private final Map<String, String> additionalHeaders = new ConcurrentHashMap<>();
-
   public ControllerClient(String clusterName, String discoveryUrls) {
     this(clusterName, discoveryUrls, Optional.empty());
+  }
+
+  public ControllerClient(String clusterName, String discoveryUrls, Optional<SSLFactory> sslFactory) {
+    this(clusterName, discoveryUrls, sslFactory, null);
   }
 
   /**
    * @param discoveryUrls comma-delimited urls to find leader controller.
    */
-  public ControllerClient(String clusterName, String discoveryUrls, Optional<SSLFactory> sslFactory) {
+  public ControllerClient(String clusterName, String discoveryUrls, Optional<SSLFactory> sslFactory, String token) {
     if (StringUtils.isEmpty(discoveryUrls)) {
       throw new VeniceException("Controller discovery url list is empty: " + discoveryUrls);
     }
 
     this.sslFactory = sslFactory;
+    this.token = token;
     this.clusterName = clusterName;
     this.controllerDiscoveryUrls =
         Arrays.stream(discoveryUrls.split(",")).map(String::trim).collect(Collectors.toList());
@@ -144,19 +146,36 @@ public class ControllerClient implements Closeable {
       String discoveryUrls,
       Optional<SSLFactory> sslFactory,
       int retryAttempts) {
-    String clusterName = discoverCluster(discoveryUrls, storeName, sslFactory, retryAttempts).getCluster();
-    return constructClusterControllerClient(clusterName, discoveryUrls, sslFactory);
+    return discoverAndConstructControllerClient(storeName, discoveryUrls, sslFactory, retryAttempts, null);
+  }
+
+  public static ControllerClient discoverAndConstructControllerClient(
+      String storeName,
+      String discoveryUrls,
+      Optional<SSLFactory> sslFactory,
+      int retryAttempts,
+      String token) {
+    String clusterName = discoverCluster(discoveryUrls, storeName, sslFactory, retryAttempts, token).getCluster();
+    return constructClusterControllerClient(clusterName, discoveryUrls, sslFactory, token);
   }
 
   public static ControllerClient constructClusterControllerClient(String clusterName, String discoveryUrls) {
-    return constructClusterControllerClient(clusterName, discoveryUrls, Optional.empty());
+    return constructClusterControllerClient(clusterName, discoveryUrls, Optional.empty(), null);
   }
 
   public static ControllerClient constructClusterControllerClient(
       String clusterName,
       String discoveryUrls,
       Optional<SSLFactory> sslFactory) {
-    return ControllerClientFactory.getControllerClient(clusterName, discoveryUrls, sslFactory);
+    return ControllerClientFactory.getControllerClient(clusterName, discoveryUrls, sslFactory, null);
+  }
+
+  public static ControllerClient constructClusterControllerClient(
+      String clusterName,
+      String discoveryUrls,
+      Optional<SSLFactory> sslFactory,
+      String token) {
+    return ControllerClientFactory.getControllerClient(clusterName, discoveryUrls, sslFactory, token);
   }
 
   @Override
@@ -170,21 +189,12 @@ public class ControllerClient implements Closeable {
     ControllerClientFactory.release(this);
   }
 
-  /**
-   * Add additional headers to the request, for instance Authentication headers.
-   * @param header the header name
-   * @param value the value
-   */
-  public void addHeader(String header, String value) {
-    additionalHeaders.put(header, value);
-  }
-
   protected String discoverLeaderController() {
     List<String> urls = new ArrayList<>(this.controllerDiscoveryUrls);
     Collections.shuffle(urls);
 
     Exception lastException = null;
-    try (ControllerTransport transport = new ControllerTransport(sslFactory).addHeaders(additionalHeaders)) {
+    try (ControllerTransport transport = new ControllerTransport(sslFactory, token)) {
       for (String url: urls) {
         try {
           String leaderControllerUrl =
@@ -966,7 +976,7 @@ public class ControllerClient implements Closeable {
 
   public ClusterStaleDataAuditResponse getClusterStaleStores(String clusterName, String parentControllerUrl) {
     QueryParams params = newParams().add(CLUSTER, clusterName);
-    try (ControllerTransport transport = new ControllerTransport(sslFactory).addHeaders(additionalHeaders)) {
+    try (ControllerTransport transport = new ControllerTransport(sslFactory, token)) {
       return transport.request(
           parentControllerUrl,
           ControllerRoute.GET_STALE_STORES_IN_CLUSTER,
@@ -1004,7 +1014,8 @@ public class ControllerClient implements Closeable {
       String discoveryUrls,
       String storeName,
       Optional<SSLFactory> sslFactory,
-      int retryAttempts) {
+      int retryAttempts,
+      String token) {
     try (ControllerClient client = new ControllerClient("*", discoveryUrls, sslFactory)) {
       return retryableRequest(client, retryAttempts, c -> c.discoverCluster(storeName));
     }
@@ -1015,7 +1026,7 @@ public class ControllerClient implements Closeable {
     Collections.shuffle(urls);
 
     Exception lastException = null;
-    try (ControllerTransport transport = new ControllerTransport(sslFactory)) {
+    try (ControllerTransport transport = new ControllerTransport(sslFactory, token)) {
       for (String url: urls) {
         try {
           // Because the way to get parameter is different between controller and router, in order to support query
@@ -1216,7 +1227,7 @@ public class ControllerClient implements Closeable {
       byte[] data) {
     Exception lastException = null;
     boolean logErrorMessage = true;
-    try (ControllerTransport transport = new ControllerTransport(sslFactory).addHeaders(additionalHeaders)) {
+    try (ControllerTransport transport = new ControllerTransport(sslFactory, token)) {
       for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
         try {
           return transport.request(getLeaderControllerUrl(), route, params, responseType, timeoutMs, data);

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
@@ -14,10 +14,11 @@ public class ControllerClientFactory {
   public static ControllerClient getControllerClient(
       String clusterName,
       String discoveryUrls,
-      Optional<SSLFactory> sslFactory) {
+      Optional<SSLFactory> sslFactory,
+      String token) {
     final String clientIdentifier = clusterName + discoveryUrls;
     return SHARED_OBJECT_FACTORY.get(clientIdentifier, () -> {
-      ControllerClient client = new ControllerClient(clusterName, discoveryUrls, sslFactory);
+      ControllerClient client = new ControllerClient(clusterName, discoveryUrls, sslFactory, token);
       CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.put(client, clientIdentifier);
       return client;
     }, client -> {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
@@ -53,20 +53,15 @@ public class ControllerTransport implements AutoCloseable {
   private final CloseableHttpAsyncClient httpClient;
   private Map<String, String> additionalHeaders = new ConcurrentHashMap<>();
 
-  public ControllerTransport(Optional<SSLFactory> sslFactory) {
+  public ControllerTransport(Optional<SSLFactory> sslFactory, String token) {
     this.httpClient = HttpAsyncClients.custom()
         .setDefaultRequestConfig(this.REQUEST_CONFIG)
         .setSSLStrategy(sslFactory.isPresent() ? new SSLIOSessionStrategy(sslFactory.get().getSSLContext()) : null)
         .build();
     this.httpClient.start();
-  }
-
-  /**
-   * Add additional headers to the request, for instance Authentication headers.
-   */
-  public ControllerTransport addHeaders(Map<String, String> headers) {
-    additionalHeaders.putAll(headers);
-    return this;
+    if (token != null && !token.isEmpty()) {
+      this.additionalHeaders.put("Authorization", "Bearer " + token);
+    }
   }
 
   public static ObjectMapper getObjectMapper() {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestControllerEnforceSSL.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestControllerEnforceSSL.java
@@ -54,7 +54,8 @@ public class TestControllerEnforceSSL {
         ControllerClient secureControllerClient = ControllerClient.constructClusterControllerClient(
             CLUSTER_NAME,
             controllerWrapper.getSecureControllerUrl(),
-            Optional.of(SslUtils.getVeniceLocalSslFactory()))) {
+            Optional.of(SslUtils.getVeniceLocalSslFactory()),
+            null)) {
       TestUtils.waitForNonDeterministicCompletion(
           5,
           TimeUnit.SECONDS,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestAdminSparkServer.java
@@ -869,7 +869,12 @@ public class TestAdminSparkServer extends AbstractTestAdminSparkServer {
     try {
       Assert.assertEquals(
           ControllerClient
-              .discoverCluster(cluster.getLeaderVeniceController().getControllerUrl(), storeName, Optional.empty(), 1)
+              .discoverCluster(
+                  cluster.getLeaderVeniceController().getControllerUrl(),
+                  storeName,
+                  Optional.empty(),
+                  1,
+                  null)
               .getCluster(),
           cluster.getClusterName(),
           "Should be able to find the cluster which the given store belongs to.");

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestBackupControllerResponse.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/server/TestBackupControllerResponse.java
@@ -29,7 +29,7 @@ public class TestBackupControllerResponse {
     try (ZkServerWrapper zkServer = ServiceFactory.getZkServer();
         PubSubBrokerWrapper kafka =
             ServiceFactory.getPubSubBroker(new PubSubBrokerConfigs.Builder().setZkWrapper(zkServer).build());
-        ControllerTransport transport = new ControllerTransport(Optional.empty());
+        ControllerTransport transport = new ControllerTransport(Optional.empty(), null);
         VeniceControllerWrapper controller1 = ServiceFactory
             .getVeniceController(new VeniceControllerCreateOptions.Builder(clusterName, zkServer, kafka).build());
         VeniceControllerWrapper controller2 = ServiceFactory

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/ServiceFactory.java
@@ -164,6 +164,8 @@ public class ServiceFactory {
           Optional.empty(),
           false,
           Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
           bannedRoutes,
           null,
           false,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerCreateOptions.java
@@ -8,6 +8,7 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_REPLICATION_FACTOR;
 import static com.linkedin.venice.integration.utils.VeniceControllerWrapper.DEFAULT_PARENT_DATA_CENTER_REGION_NAME;
 
+import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import java.util.Arrays;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class VeniceControllerCreateOptions {
   private final PubSubBrokerWrapper kafkaBroker;
   private final Properties extraProperties;
   private final AuthorizerService authorizerService;
+  private final AuthenticationService authenticationService;
   private final String regionName;
 
   private VeniceControllerCreateOptions(Builder builder) {
@@ -48,6 +50,7 @@ public class VeniceControllerCreateOptions {
     zkServer = builder.zkServer;
     kafkaBroker = builder.kafkaBroker;
     extraProperties = builder.extraProperties;
+    authenticationService = builder.authenticationService;
     authorizerService = builder.authorizerService;
     isParent = builder.childControllers != null && builder.childControllers.length != 0;
     regionName = builder.regionName;
@@ -172,6 +175,10 @@ public class VeniceControllerCreateOptions {
     return authorizerService;
   }
 
+  public AuthenticationService getAuthenticationService() {
+    return authenticationService;
+  }
+
   public String getRegionName() {
     return regionName;
   }
@@ -192,6 +199,7 @@ public class VeniceControllerCreateOptions {
     private VeniceControllerWrapper[] childControllers = null;
     private Properties extraProperties = new Properties();
     private AuthorizerService authorizerService;
+    private AuthenticationService authenticationService;
     private String regionName = "";
 
     public Builder(String[] clusterNames, ZkServerWrapper zkServer, PubSubBrokerWrapper kafkaBroker) {
@@ -258,6 +266,11 @@ public class VeniceControllerCreateOptions {
 
     public Builder authorizerService(AuthorizerService authorizerService) {
       this.authorizerService = authorizerService;
+      return this;
+    }
+
+    public Builder authenticationService(AuthenticationService authenticationService) {
+      this.authenticationService = authenticationService;
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceControllerWrapper.java
@@ -321,6 +321,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
           metricsRepository,
           d2ServerList,
           Optional.empty(),
+          Optional.ofNullable(options.getAuthenticationService()),
           Optional.ofNullable(options.getAuthorizerService()),
           d2Client,
           consumerClientConfig,
@@ -409,7 +410,7 @@ public class VeniceControllerWrapper extends ProcessWrapper {
       d2ServerList.add(createD2Server(zkAddress, securePort, true, isParent));
     }
     D2Client d2Client = D2TestUtils.getAndStartD2Client(zkAddress);
-    service = new VeniceController(configs, d2ServerList, Optional.empty(), d2Client);
+    service = new VeniceController(configs, d2ServerList, Optional.empty(), Optional.empty(), d2Client);
   }
 
   /***

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceController.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controller;
 
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.authentication.AuthenticationServiceUtils.buildAuthenticationService;
+import static com.linkedin.venice.authorization.AuthorizerServiceUtils.buildAuthorizerService;
 
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.d2.balancer.D2ClientBuilder;
@@ -269,6 +270,7 @@ public class VeniceController {
     Utils.closeQuietlyWithErrorLogged(secureAdminServer);
     Utils.closeQuietlyWithErrorLogged(controllerService);
     authenticationService.ifPresent(Utils::closeQuietlyWithErrorLogged);
+    authorizerService.ifPresent(Utils::closeQuietlyWithErrorLogged);
   }
 
   /**
@@ -304,12 +306,13 @@ public class VeniceController {
         new D2ClientBuilder().setZkHosts(controllerProps.getString(ZOOKEEPER_ADDRESS)).setIsSSLEnabled(false).build();
 
     Optional<AuthenticationService> authenticationService = buildAuthenticationService(controllerProps);
+    Optional<AuthorizerService> authorizerService = buildAuthorizerService(controllerProps);
     D2ClientUtils.startClient(d2Client);
     VeniceController controller = new VeniceController(
         Arrays.asList(new VeniceProperties[] { controllerProps }),
         new ArrayList<>(),
         authenticationService,
-        Optional.empty(),
+        authorizerService,
         d2Client);
     controller.start();
     addShutdownHook(controller, d2Client);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.CommonConfigKeys.AUTHENTICATION_TOKEN;
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_ALLOWLIST;
@@ -130,6 +131,7 @@ public class VeniceControllerClusterConfig {
   // SSL related config
   Optional<SSLConfig> sslConfig;
   private String sslFactoryClassName;
+  private String token;
   private int refreshAttemptsForZkReconnect;
   private long refreshIntervalForZkReconnectInMs;
   private boolean enableOfflinePushSSLAllowlist;
@@ -384,6 +386,7 @@ public class VeniceControllerClusterConfig {
       sslConfig = Optional.empty();
     }
     sslFactoryClassName = props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME);
+    token = props.getString(AUTHENTICATION_TOKEN, "");
     refreshAttemptsForZkReconnect = props.getInt(REFRESH_ATTEMPTS_FOR_ZK_RECONNECT, 3);
     refreshIntervalForZkReconnectInMs =
         props.getLong(REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS, java.util.concurrent.TimeUnit.SECONDS.toMillis(10));
@@ -565,6 +568,10 @@ public class VeniceControllerClusterConfig {
 
   public String getSslFactoryClassName() {
     return sslFactoryClassName;
+  }
+
+  public String getToken() {
+    return token;
   }
 
   public int getRefreshAttemptsForZkReconnect() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -101,6 +101,10 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getSslFactoryClassName();
   }
 
+  public String getToken() {
+    return getCommonConfig().getToken();
+  }
+
   public boolean isDisableParentRequestTopicForStreamPushes() {
     return getCommonConfig().isDisableParentRequestTopicForStreamPushes();
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
@@ -6,6 +6,11 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.NAME;
 
 import com.linkedin.venice.acl.AclException;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
+import com.linkedin.venice.authorization.Method;
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.authorization.Resource;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
@@ -31,8 +36,19 @@ public class AbstractRoute {
   private static final ResourceAclCheck READ_ACCESS_TO_TOPIC =
       (cert, resourceName, aclClient) -> aclClient.hasAccessToTopic(cert, resourceName, "Read");
 
+  private static final PermissionAssertion ASSERT_ACCESS_TO_STORE =
+      (principal, resource, auth) -> auth.canAccess(Method.GET, resource, principal);
+  // A singleton of acl check function against topic resource
+  private static final PermissionAssertion ASSERT_WRITE_ACCESS_TO_TOPIC =
+      (principal, resource, auth) -> auth.canAccess(Method.Write, resource, principal);
+
+  private static final PermissionAssertion ASSERT_READ_ACCESS_TO_TOPIC =
+      (principal, resource, auth) -> auth.canAccess(Method.Read, resource, principal);
+
   private final boolean sslEnabled;
   private final Optional<DynamicAccessController> accessController;
+  private final Optional<AuthenticationService> authenticationService;
+  private final Optional<AuthorizerService> authorizerService;
 
   /**
    * Default constructor for different controller request routes.
@@ -41,25 +57,48 @@ public class AbstractRoute {
    * through this constructor; make sure Nuage is also in the allowlist so that they can create stores
    * @param accessController the access client that check whether a certificate can access a resource
    */
-  public AbstractRoute(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
+  public AbstractRoute(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
     this.sslEnabled = sslEnabled;
+    this.authenticationService = authenticationService;
     this.accessController = accessController;
+    this.authorizerService = authorizerService;
   }
 
   /**
    * Check whether the user certificate in request has access to the store specified in
    * the request.
    */
-  private boolean hasAccess(Request request, ResourceAclCheck aclCheckFunction) {
+  private boolean hasAccess(Request request, ResourceAclCheck aclCheckFunction, PermissionAssertion assertion) {
+    Principal principal = getPrincipal(request);
+    LOGGER.info("hasAccess {} {} {}", request, principal, authenticationService);
+
+    String storeName = request.queryParams(NAME);
+
+    if (authorizerService.isPresent()) {
+      boolean allowed = assertion.apply(principal, new Resource(storeName), authorizerService.get());
+      if (!allowed) {
+        LOGGER.warn(
+            "Client {} [host:{} IP:{}] doesn't have access to store {}",
+            principal,
+            request.host(),
+            request.ip(),
+            storeName);
+        return false;
+      }
+    }
+
     if (!isAclEnabled()) {
       /**
        * Grant access if it's not required to check ACL.
        */
       return true;
     }
-    X509Certificate certificate = getCertificate(request);
 
-    String storeName = request.queryParams(NAME);
+    X509Certificate certificate = getCertificate(request);
     /**
      * Currently Nuage only supports adding GET/POST methods for a store resource
      * TODO: Feature request for Nuage to support other method like PUT or customized methods
@@ -92,20 +131,36 @@ public class AbstractRoute {
    * Check whether the user has "Write" method access to the related version topics.
    */
   protected boolean hasWriteAccessToTopic(Request request) {
-    return hasAccess(request, WRITE_ACCESS_TO_TOPIC);
+    return hasAccess(request, WRITE_ACCESS_TO_TOPIC, ASSERT_WRITE_ACCESS_TO_TOPIC);
   }
 
   /**
    * Check whether the user has "Read" method access to the related version topics.
    */
   protected boolean hasReadAccessToTopic(Request request) {
-    return hasAccess(request, READ_ACCESS_TO_TOPIC);
+    return hasAccess(request, READ_ACCESS_TO_TOPIC, ASSERT_READ_ACCESS_TO_TOPIC);
+  }
+
+  protected Principal getPrincipal(Request request) {
+    return authenticationService.map(service -> {
+      AuthenticationService.HttpRequestAccessor requestAccessor = new HttpRequestAccessor(request);
+      return service.getPrincipalFromHttpRequest(requestAccessor);
+    }).orElse(null);
   }
 
   /**
    * Get principal Id from request.
    */
   protected String getPrincipalId(Request request) {
+
+    if (authenticationService.isPresent()) {
+      Principal principal = getPrincipal(request);
+      if (principal != null) {
+        return principal.getName();
+      }
+      // fallback to legacy implementation
+    }
+
     if (!isSslEnabled()) {
       LOGGER.warn("SSL is not enabled. No certificate could be extracted from request.");
       return USER_UNKNOWN;
@@ -130,14 +185,22 @@ public class AbstractRoute {
    * ACL is not checked for requests that want to get metadata of a store/job.
    */
   protected boolean hasAccessToStore(Request request) {
-    return hasAccess(request, GET_ACCESS_TO_STORE);
+    return hasAccess(request, GET_ACCESS_TO_STORE, ASSERT_ACCESS_TO_STORE);
   }
 
   /**
    * Check whether the user is within the admin users allowlist.
    */
   protected boolean isAllowListUser(Request request) {
+    String storeName = request.queryParamOrDefault(NAME, STORE_UNKNOWN);
     if (!isAclEnabled()) {
+      if (authenticationService.isPresent()) {
+        Principal principal = getPrincipal(request);
+        if (authorizerService.isPresent()) {
+          return authorizerService.get().isSuperUser(principal, storeName);
+        }
+      }
+
       /**
        * Grant access if it's not required to check ACL.
        * {@link accessController} will be empty if ACL is not enabled.
@@ -145,8 +208,6 @@ public class AbstractRoute {
       return true;
     }
     X509Certificate certificate = getCertificate(request);
-
-    String storeName = request.queryParamOrDefault(NAME, STORE_UNKNOWN);
     return accessController.get().isAllowlistUsers(certificate, storeName, HTTP_GET);
   }
 
@@ -170,11 +231,16 @@ public class AbstractRoute {
   /**
    * Helper function to get certificate out of Spark request
    */
-  protected static X509Certificate getCertificate(Request request) {
+  protected X509Certificate getCertificate(Request request) {
     HttpServletRequest rawRequest = request.raw();
     Object certificateObject = rawRequest.getAttribute(CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME);
     if (certificateObject == null) {
-      throw new VeniceException("Client request doesn't contain certificate for store: " + request.queryParams(NAME));
+      if (accessController.isPresent()) {
+        throw new VeniceException("Client request doesn't contain certificate for store: " + request.queryParams(NAME));
+      } else {
+        // it is okay to not have certificate if legacy accessController is not configured
+        return null;
+      }
     }
     return ((X509Certificate[]) certificateObject)[0];
   }
@@ -186,5 +252,33 @@ public class AbstractRoute {
   interface ResourceAclCheck {
     boolean apply(X509Certificate clientCert, String resource, DynamicAccessController accessController)
         throws AclException;
+  }
+
+  @FunctionalInterface
+  interface PermissionAssertion {
+    boolean apply(Principal principal, Resource resource, AuthorizerService authorizerService);
+  }
+
+  private class HttpRequestAccessor implements AuthenticationService.HttpRequestAccessor {
+    private final Request request;
+
+    public HttpRequestAccessor(Request request) {
+      this.request = request;
+    }
+
+    @Override
+    public String getHeader(String headerName) {
+      return request.headers(headerName);
+    }
+
+    @Override
+    public X509Certificate getCertificate() {
+      return AbstractRoute.this.getCertificate(request);
+    }
+
+    @Override
+    public String toString() {
+      return request.toString();
+    }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AbstractRoute.java
@@ -14,6 +14,7 @@ import com.linkedin.venice.authorization.Resource;
 import com.linkedin.venice.exceptions.VeniceException;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -278,7 +279,8 @@ public class AbstractRoute {
 
     @Override
     public String toString() {
-      return request.toString();
+      return "Request {" + request.requestMethod() + ", " + request.pathInfo() + "?" + request.queryString()
+          + request.headers().stream().map(h -> h + ":" + request.headers(h)).collect(Collectors.joining()) + "}";
     }
   }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
@@ -8,6 +8,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LAST_SUCCEED_EXE
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
 import com.linkedin.venice.controllerapi.AdminCommandExecution;
@@ -17,8 +19,12 @@ import spark.Route;
 
 
 public class AdminCommandExecutionRoutes extends AbstractRoute {
-  public AdminCommandExecutionRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public AdminCommandExecutionRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminSparkServer.java
@@ -103,6 +103,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.SSLConfig;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AuditInfo;
 import com.linkedin.venice.controller.spark.VeniceSparkServerFactory;
@@ -148,6 +150,8 @@ public class AdminSparkServer extends AbstractVeniceService {
   private final boolean checkReadMethodForKafka;
   private final Optional<SSLConfig> sslConfig;
   private final Optional<DynamicAccessController> accessController;
+  private final Optional<AuthenticationService> authenticationService;
+  private final Optional<AuthorizerService> authorizerService;
 
   protected static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
   final private Map<String, SparkServerStats> statsMap;
@@ -174,6 +178,8 @@ public class AdminSparkServer extends AbstractVeniceService {
       Optional<SSLConfig> sslConfig,
       boolean checkReadMethodForKafka,
       Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
       List<ControllerRoute> disabledRoutes,
       VeniceProperties jettyConfigOverrides,
       boolean disableParentRequestTopicForStreamPushes,
@@ -184,6 +190,8 @@ public class AdminSparkServer extends AbstractVeniceService {
     this.sslConfig = sslConfig;
     this.checkReadMethodForKafka = checkReadMethodForKafka;
     this.accessController = accessController;
+    this.authenticationService = authenticationService;
+    this.authorizerService = authorizerService;
     // Note: admin is passed in as a reference. The expectation is the source of the admin will
     // close it so we don't close it in stopInner()
     this.admin = admin;
@@ -273,29 +281,49 @@ public class AdminSparkServer extends AbstractVeniceService {
     });
 
     // Build all different routes
-    ControllerRoutes controllerRoutes = new ControllerRoutes(sslEnabled, accessController, pubSubTopicRepository);
-    StoresRoutes storesRoutes = new StoresRoutes(sslEnabled, accessController, pubSubTopicRepository);
-    JobRoutes jobRoutes = new JobRoutes(sslEnabled, accessController);
-    SkipAdminRoute skipAdminRoute = new SkipAdminRoute(sslEnabled, accessController);
+    ControllerRoutes controllerRoutes = new ControllerRoutes(
+        sslEnabled,
+        accessController,
+        pubSubTopicRepository,
+        authenticationService,
+        authorizerService);
+    StoresRoutes storesRoutes =
+        new StoresRoutes(sslEnabled, accessController, pubSubTopicRepository, authenticationService, authorizerService);
+    JobRoutes jobRoutes = new JobRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    SkipAdminRoute skipAdminRoute =
+        new SkipAdminRoute(sslEnabled, accessController, authenticationService, authorizerService);
+
     CreateVersion createVersion = new CreateVersion(
         sslEnabled,
         accessController,
         this.checkReadMethodForKafka,
-        disableParentRequestTopicForStreamPushes);
-    CreateStore createStoreRoute = new CreateStore(sslEnabled, accessController);
-    NodesAndReplicas nodesAndReplicas = new NodesAndReplicas(sslEnabled, accessController);
-    SchemaRoutes schemaRoutes = new SchemaRoutes(sslEnabled, accessController);
+        disableParentRequestTopicForStreamPushes,
+        authenticationService,
+        authorizerService);
+    CreateStore createStoreRoute =
+        new CreateStore(sslEnabled, accessController, authenticationService, authorizerService);
+    NodesAndReplicas nodesAndReplicas =
+        new NodesAndReplicas(sslEnabled, accessController, authenticationService, authorizerService);
+    SchemaRoutes schemaRoutes =
+        new SchemaRoutes(sslEnabled, accessController, authenticationService, authorizerService);
     AdminCommandExecutionRoutes adminCommandExecutionRoutes =
-        new AdminCommandExecutionRoutes(sslEnabled, accessController);
+        new AdminCommandExecutionRoutes(sslEnabled, accessController, authenticationService, authorizerService);
     RoutersClusterConfigRoutes routersClusterConfigRoutes =
-        new RoutersClusterConfigRoutes(sslEnabled, accessController);
-    MigrationRoutes migrationRoutes = new MigrationRoutes(sslEnabled, accessController);
-    VersionRoute versionRoute = new VersionRoute(sslEnabled, accessController);
-    ClusterRoutes clusterRoutes = new ClusterRoutes(sslEnabled, accessController);
-    NewClusterBuildOutRoutes newClusterBuildOutRoutes = new NewClusterBuildOutRoutes(sslEnabled, accessController);
-    DataRecoveryRoutes dataRecoveryRoutes = new DataRecoveryRoutes(sslEnabled, accessController);
-    AdminTopicMetadataRoutes adminTopicMetadataRoutes = new AdminTopicMetadataRoutes(sslEnabled, accessController);
-    StoragePersonaRoutes storagePersonaRoutes = new StoragePersonaRoutes(sslEnabled, accessController);
+        new RoutersClusterConfigRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    MigrationRoutes migrationRoutes =
+        new MigrationRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    VersionRoute versionRoute =
+        new VersionRoute(sslEnabled, accessController, authenticationService, authorizerService);
+    ClusterRoutes clusterRoutes =
+        new ClusterRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    NewClusterBuildOutRoutes newClusterBuildOutRoutes =
+        new NewClusterBuildOutRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    DataRecoveryRoutes dataRecoveryRoutes =
+        new DataRecoveryRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    AdminTopicMetadataRoutes adminTopicMetadataRoutes =
+        new AdminTopicMetadataRoutes(sslEnabled, accessController, authenticationService, authorizerService);
+    StoragePersonaRoutes storagePersonaRoutes =
+        new StoragePersonaRoutes(sslEnabled, accessController, authenticationService, authorizerService);
 
     httpService.get(SET_VERSION.getPath(), (request, response) -> {
       response.type(HttpConstants.TEXT_HTML);

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -10,6 +10,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_TOP
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
 import com.linkedin.venice.controllerapi.AdminTopicMetadataResponse;
@@ -24,8 +26,12 @@ import spark.Route;
 
 
 public class AdminTopicMetadataRoutes extends AbstractRoute {
-  public AdminTopicMetadataRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public AdminTopicMetadataRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterRoutes.java
@@ -10,6 +10,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_CLUSTER_C
 import static com.linkedin.venice.controllerapi.ControllerRoute.WIPE_CLUSTER;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiStoreTopicsResponse;
@@ -23,8 +25,12 @@ import spark.Route;
 
 
 public class ClusterRoutes extends AbstractRoute {
-  public ClusterRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public ClusterRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -13,6 +13,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOP
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ChildAwareResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -35,8 +37,10 @@ public class ControllerRoutes extends AbstractRoute {
   public ControllerRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      PubSubTopicRepository pubSubTopicRepository) {
-    super(sslEnabled, accessController);
+      PubSubTopicRepository pubSubTopicRepository,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
     this.pubSubTopicRepository = pubSubTopicRepository;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateStore.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateStore.java
@@ -14,6 +14,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ACL;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.AclResponse;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -24,8 +26,12 @@ import spark.Route;
 
 
 public class CreateStore extends AbstractRoute {
-  public CreateStore(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public CreateStore(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -27,6 +27,8 @@ import static com.linkedin.venice.meta.Version.REPLICATION_METADATA_VERSION_ID_U
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -63,8 +65,10 @@ public class CreateVersion extends AbstractRoute {
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
       boolean checkReadMethodForKafka,
-      boolean disableParentRequestTopicForStreamPushes) {
-    super(sslEnabled, accessController);
+      boolean disableParentRequestTopicForStreamPushes,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
     this.checkReadMethodForKafka = checkReadMethodForKafka;
     this.disableParentRequestTopicForStreamPushes = disableParentRequestTopicForStreamPushes;
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
@@ -13,6 +13,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.IS_STORE_VERSION
 import static com.linkedin.venice.controllerapi.ControllerRoute.PREPARE_DATA_RECOVERY;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.ReadyForDataRecoveryResponse;
@@ -31,8 +33,12 @@ import spark.Route;
 public class DataRecoveryRoutes extends AbstractRoute {
   private final VeniceJsonSerializer<Version> versionVeniceJsonSerializer = new VeniceJsonSerializer<>(Version.class);
 
-  public DataRecoveryRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public DataRecoveryRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/JobRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/JobRoutes.java
@@ -15,6 +15,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SEND_PUSH_JOB_DE
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.IncrementalPushVersionsResponse;
@@ -42,8 +44,12 @@ public class JobRoutes extends AbstractRoute {
   private final InternalAvroSpecificSerializer<PushJobDetails> pushJobDetailsSerializer =
       AvroProtocolDefinition.PUSH_JOB_DETAILS.getSerializer();
 
-  public JobRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public JobRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/MigrationRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/MigrationRoutes.java
@@ -6,6 +6,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SET_MIGRATION_PU
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MigrationPushStrategyResponse;
@@ -16,8 +18,12 @@ import spark.Route;
 
 
 public class MigrationRoutes extends AbstractRoute {
-  public MigrationRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public MigrationRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NewClusterBuildOutRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NewClusterBuildOutRoutes.java
@@ -7,6 +7,8 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FA
 import static com.linkedin.venice.controllerapi.ControllerRoute.REPLICATE_META_DATA;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.StoreResponse;
 import com.linkedin.venice.meta.StoreInfo;
@@ -16,8 +18,12 @@ import spark.Route;
 
 
 public class NewClusterBuildOutRoutes extends AbstractRoute {
-  public NewClusterBuildOutRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public NewClusterBuildOutRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
@@ -20,6 +20,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_NODE;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.NodeRemovableResult;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -55,8 +57,12 @@ public class NodesAndReplicas extends AbstractRoute {
   /**
    * TODO: Make sure services "venice-hooks-deployable" is also in allowlist
    */
-  public NodesAndReplicas(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public NodesAndReplicas(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
@@ -9,6 +9,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.ENABLE_THROTTLIN
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ROUTERS_CLUSTER_CONFIG;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.RoutersClusterConfigResponse;
@@ -19,8 +21,12 @@ import spark.Route;
 
 
 public class RoutersClusterConfigRoutes extends AbstractRoute {
-  public RoutersClusterConfigRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public RoutersClusterConfigRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -18,6 +18,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_DERIVED_S
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
 import com.linkedin.venice.controllerapi.MultiSchemaResponse;
@@ -44,8 +46,12 @@ import spark.Route;
 
 
 public class SchemaRoutes extends AbstractRoute {
-  public SchemaRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public SchemaRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
@@ -7,6 +7,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SKIP_ADMIN;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.exceptions.ErrorType;
@@ -17,8 +19,12 @@ import spark.Route;
 
 
 public class SkipAdminRoute extends AbstractRoute {
-  public SkipAdminRoute(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public SkipAdminRoute(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoragePersonaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoragePersonaRoutes.java
@@ -11,6 +11,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.GET_STORAGE_PERS
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
 import com.linkedin.venice.controllerapi.MultiStoragePersonaResponse;
@@ -27,8 +29,12 @@ import spark.Route;
 
 
 public class StoragePersonaRoutes extends AbstractRoute {
-  public StoragePersonaRoutes(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public StoragePersonaRoutes(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -53,6 +53,8 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
 import com.linkedin.venice.controller.kafka.TopicCleanupService;
@@ -112,8 +114,10 @@ public class StoresRoutes extends AbstractRoute {
   public StoresRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      PubSubTopicRepository pubSubTopicRepository) {
-    super(sslEnabled, accessController);
+      PubSubTopicRepository pubSubTopicRepository,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
     this.pubSubTopicRepository = pubSubTopicRepository;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VersionRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VersionRoute.java
@@ -4,6 +4,8 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_BOOTSTRAPPING_VERSIONS;
 
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.MultiVersionStatusResponse;
 import java.util.Optional;
@@ -12,8 +14,12 @@ import spark.Route;
 
 
 public class VersionRoute extends AbstractRoute {
-  public VersionRoute(boolean sslEnabled, Optional<DynamicAccessController> accessController) {
-    super(sslEnabled, accessController);
+  public VersionRoute(
+      boolean sslEnabled,
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService) {
+    super(sslEnabled, accessController, authenticationService, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -40,7 +40,8 @@ public class ControllerRoutesTest {
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
 
     Route leaderControllerRoute =
-        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository).getLeaderController(mockAdmin);
+        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, Optional.empty(), Optional.empty())
+            .getLeaderController(mockAdmin);
     LeaderControllerResponse leaderControllerResponse = ObjectMapperFactory.getInstance()
         .readValue(
             leaderControllerRoute.handle(request, mock(Response.class)).toString(),
@@ -50,7 +51,8 @@ public class ControllerRoutesTest {
     Assert.assertEquals(leaderControllerResponse.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
 
     Route leaderControllerSslRoute =
-        new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository).getLeaderController(mockAdmin);
+        new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository, Optional.empty(), Optional.empty())
+            .getLeaderController(mockAdmin);
     LeaderControllerResponse leaderControllerResponseSsl = ObjectMapperFactory.getInstance()
         .readValue(
             leaderControllerSslRoute.handle(request, mock(Response.class)).toString(),

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateStoreTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateStoreTest.java
@@ -53,7 +53,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -82,7 +82,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
   }
@@ -102,7 +102,7 @@ public class CreateStoreTest {
 
     doReturn(clusterName).when(request).queryParams(CLUSTER);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpStatus.SC_BAD_REQUEST);
@@ -127,7 +127,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpConstants.SC_MISDIRECTED_REQUEST);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -108,7 +108,8 @@ public class CreateVersionTest {
     /**
      * Build a CreateVersion route.
      */
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     // Not an allowlist user.
@@ -169,7 +170,8 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -221,7 +223,8 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -273,7 +276,8 @@ public class CreateVersionTest {
     assertTrue(admin.isParent());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false);
+    CreateVersion createVersion =
+        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
     Object result = createVersionRoute.handle(request, response);
     assertNotNull(result);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
@@ -33,7 +33,7 @@ public class JobRoutesTest {
     String cluster = Utils.getUniqueString("cluster");
     String store = Utils.getUniqueString("store");
     int version = 5;
-    JobRoutes jobRoutes = new JobRoutes(false, Optional.empty());
+    JobRoutes jobRoutes = new JobRoutes(false, Optional.empty(), Optional.empty(), Optional.empty());
     JobStatusQueryResponse response =
         jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty(), null);
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
@@ -24,7 +24,7 @@ public class SchemaRoutesTest {
     Admin admin = mock(Admin.class);
     when(admin.getValueSchemaId(cluster, store, schemaStr)).thenReturn(SchemaData.INVALID_VALUE_SCHEMA_ID);
     when(admin.getStore(cluster, store)).thenReturn(null);
-    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty());
+    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty(), Optional.empty(), Optional.empty());
     try {
       schemaRoutes.populateSchemaResponseForValueOrDerivedSchemaID(admin, cluster, store, schemaStr);
     } catch (VeniceNoStoreException e) {

--- a/services/venice-standalone/config/controller.properties
+++ b/services/venice-standalone/config/controller.properties
@@ -35,3 +35,6 @@ enable.offline.push.ssl.whitelist=false
 kafka.linger.ms=0
 default.partition.count=1
 controller.zk.shared.metadata.system.schema.store.auto.creation.enabled=true
+
+
+authentication.service.class=com.linkedin.venice.authentication.LogOnlyAuthenticationService


### PR DESCRIPTION
## Summary, imperative, start upper case, don't end with a period

This is a POC PR that introduces a set of changes to Venice in order to be able to perform JWT authentication and also require that the user is Authenticated before performing any operations.

- new AuthenticationService interface
- a JWT implementation for AuthenticationService
- allow to configure the AuthenticationService and the AuthorizerService interfaces
- implement a basic AuthorizerService that requires that every request has a Principal
- add "-token" parameter to the "Admin tool" in order to perform operations

Remaining tasks:
- Add tests, tests, tests...
- Ensure that every call to the Controller is able to be authenticated (there will be changes in the Server, in the Router and in the other clients....)

Mid term tasks:
- split AuthorizerService, now it performs authorization AND ACL management, they should be distinct interfaces
- split AbstractRoute.getCertificate() +  DynamicAccessController into a pair of  AuthenticationService and AuthorizerService

## How was this PR tested?

TODO, only manually at the moment + 1 base end-to-end unit test
