### PR TITLE
[server][pulsar-sink] More fixes about SASL authentication

### DIFF
--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1045,10 +1045,10 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       clonedProperties.setProperty(KAFKA_BOOTSTRAP_SERVERS, kafkaBootstrapUrls);
       serverConfig = new VeniceServerConfig(new VeniceProperties(clonedProperties), serverConfig.getKafkaClusterMap());
     }
-
     VeniceProperties clusterProperties = serverConfig.getClusterProperties();
+    LOGGER.info("Using cluster properties: {}", clusterProperties);
     Properties properties = new Properties();
-    ApacheKafkaProducerConfig.copyKafkaSASLProperties(clusterProperties, properties);
+    ApacheKafkaProducerConfig.copyKafkaSASLProperties(clusterProperties, properties, false);
     kafkaBootstrapUrls = serverConfig.getKafkaBootstrapServers();
     String resolvedKafkaUrl = serverConfig.getKafkaClusterUrlResolver().apply(kafkaBootstrapUrls);
     if (resolvedKafkaUrl != null) {

--- a/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
+++ b/clients/da-vinci-client/src/main/java/com/linkedin/davinci/kafka/consumer/KafkaStoreIngestionService.java
@@ -1046,7 +1046,6 @@ public class KafkaStoreIngestionService extends AbstractVeniceService implements
       serverConfig = new VeniceServerConfig(new VeniceProperties(clonedProperties), serverConfig.getKafkaClusterMap());
     }
     VeniceProperties clusterProperties = serverConfig.getClusterProperties();
-    LOGGER.info("Using cluster properties: {}", clusterProperties);
     Properties properties = new Properties();
     ApacheKafkaProducerConfig.copyKafkaSASLProperties(clusterProperties, properties, false);
     kafkaBootstrapUrls = serverConfig.getKafkaBootstrapServers();

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
@@ -225,7 +225,7 @@ public class VeniceSink implements Sink<GenericObject> {
     }
   }
 
-  private Map<String, String> getConfig(VeniceSinkConfig veniceCfg, String systemName) {
+  private static Map<String, String> getConfig(VeniceSinkConfig veniceCfg, String systemName) {
     Map<String, String> config = new HashMap<>();
     String configPrefix = SYSTEMS_PREFIX + systemName + DOT;
     config.put(configPrefix + VENICE_PUSH_TYPE, Version.PushType.INCREMENTAL.toString());
@@ -243,9 +243,9 @@ public class VeniceSink implements Sink<GenericObject> {
     config.put("kafka.sasl.mechanism", veniceCfg.getKafkaSaslMechanism());
     config.put("kafka.security.protocol", veniceCfg.getKafkaSecurityProtocol());
 
-    if (this.config.getWriterConfig() != null && !this.config.getWriterConfig().isEmpty()) {
-      LOGGER.info("Additional WriterConfig: {}", this.config.getWriterConfig());
-      config.putAll(this.config.getWriterConfig());
+    if (veniceCfg.getWriterConfig() != null && !veniceCfg.getWriterConfig().isEmpty()) {
+      LOGGER.info("Additional WriterConfig: {}", veniceCfg.getWriterConfig());
+      config.putAll(veniceCfg.getWriterConfig());
     }
 
     LOGGER.info("CONFIG: {}", config);

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.pulsar.sink;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
+import static com.linkedin.venice.ConfigKeys.VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DEPLOYMENT_ID;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DOT;
 import static com.linkedin.venice.samza.VeniceSystemFactory.SYSTEMS_PREFIX;
@@ -231,6 +232,8 @@ public class VeniceSink implements Sink<GenericObject> {
     config.put(configPrefix + VENICE_PUSH_TYPE, Version.PushType.INCREMENTAL.toString());
     config.put(configPrefix + VENICE_STORE, veniceCfg.getStoreName());
     config.put(configPrefix + VENICE_AGGREGATE, "false");
+    config.put(VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION, "false");
+
     config.put("venice.discover.urls", veniceCfg.getVeniceDiscoveryUrl());
     config.put(VENICE_CONTROLLER_DISCOVERY_URL, veniceCfg.getVeniceDiscoveryUrl());
     config.put(VENICE_ROUTER_URL, veniceCfg.getVeniceRouterUrl());

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
@@ -1,7 +1,6 @@
 package com.linkedin.venice.pulsar.sink;
 
 import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
-import static com.linkedin.venice.ConfigKeys.VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DEPLOYMENT_ID;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DOT;
 import static com.linkedin.venice.samza.VeniceSystemFactory.SYSTEMS_PREFIX;
@@ -226,13 +225,12 @@ public class VeniceSink implements Sink<GenericObject> {
     }
   }
 
-  private static Map<String, String> getConfig(VeniceSinkConfig veniceCfg, String systemName) {
+  private Map<String, String> getConfig(VeniceSinkConfig veniceCfg, String systemName) {
     Map<String, String> config = new HashMap<>();
     String configPrefix = SYSTEMS_PREFIX + systemName + DOT;
     config.put(configPrefix + VENICE_PUSH_TYPE, Version.PushType.INCREMENTAL.toString());
     config.put(configPrefix + VENICE_STORE, veniceCfg.getStoreName());
     config.put(configPrefix + VENICE_AGGREGATE, "false");
-    config.put(VALIDATE_VENICE_INTERNAL_SCHEMA_VERSION, "false");
 
     config.put("venice.discover.urls", veniceCfg.getVeniceDiscoveryUrl());
     config.put(VENICE_CONTROLLER_DISCOVERY_URL, veniceCfg.getVeniceDiscoveryUrl());
@@ -244,6 +242,12 @@ public class VeniceSink implements Sink<GenericObject> {
     }
     config.put("kafka.sasl.mechanism", veniceCfg.getKafkaSaslMechanism());
     config.put("kafka.security.protocol", veniceCfg.getKafkaSecurityProtocol());
+
+    if (this.config.getWriterConfig() != null && !this.config.getWriterConfig().isEmpty()) {
+      LOGGER.info("Additional WriterConfig: {}", this.config.getWriterConfig());
+      config.putAll(this.config.getWriterConfig());
+    }
+
     LOGGER.info("CONFIG: {}", config);
     return config;
   }

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSinkConfig.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSinkConfig.java
@@ -20,6 +20,7 @@ package com.linkedin.venice.pulsar.sink;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,6 +60,9 @@ public class VeniceSinkConfig implements Serializable {
 
   @FieldDoc(defaultValue = "10", help = "Max number of buffered records before flushing to Venice")
   private int maxNumberUnflushedRecords = 10;
+
+  @FieldDoc(defaultValue = "", help = "Additional configuration for the Venice writer")
+  private Map<String, String> writerConfig = new HashMap<>();
 
   public static VeniceSinkConfig load(Map<String, Object> map, SinkContext sinkContext) throws IOException {
     LOGGER.info("Loading config {}", map);
@@ -108,6 +112,11 @@ public class VeniceSinkConfig implements Serializable {
   @java.lang.SuppressWarnings("all")
   public int getMaxNumberUnflushedRecords() {
     return this.maxNumberUnflushedRecords;
+  }
+
+  @java.lang.SuppressWarnings("all")
+  public Map<String, String> getWriterConfig() {
+    return writerConfig;
   }
 
   /**
@@ -182,6 +191,11 @@ public class VeniceSinkConfig implements Serializable {
     return this;
   }
 
+  @java.lang.SuppressWarnings("all")
+  public void setWriterConfig(Map<String, String> writerConfig) {
+    this.writerConfig = writerConfig;
+  }
+
   @java.lang.Override
   @java.lang.SuppressWarnings("all")
   public boolean equals(final java.lang.Object o) {
@@ -207,6 +221,10 @@ public class VeniceSinkConfig implements Serializable {
     if (this$veniceRouterUrl == null
         ? other$veniceRouterUrl != null
         : !this$veniceRouterUrl.equals(other$veniceRouterUrl))
+      return false;
+    final java.lang.Object this$writerConfig = this.getWriterConfig();
+    final java.lang.Object other$writerConfig = other.getWriterConfig();
+    if (this$writerConfig == null ? other$writerConfig != null : !this$writerConfig.equals(other$writerConfig))
       return false;
     final java.lang.Object this$kafkaSaslConfig = this.getKafkaSaslConfig();
     final java.lang.Object other$kafkaSaslConfig = other.getKafkaSaslConfig();
@@ -258,6 +276,8 @@ public class VeniceSinkConfig implements Serializable {
     result = result * PRIME + ($kafkaSecurityProtocol == null ? 43 : $kafkaSecurityProtocol.hashCode());
     final java.lang.Object $storeName = this.getStoreName();
     result = result * PRIME + ($storeName == null ? 43 : $storeName.hashCode());
+    final java.lang.Object $writerConfig = this.getWriterConfig();
+    result = result * PRIME + ($writerConfig == null ? 43 : $writerConfig.hashCode());
     return result;
   }
 

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
@@ -37,6 +37,11 @@ public class ApacheKafkaAdminConfig {
           ConfigKeys.KAFKA_ADMIN_GET_TOPIC_CONFIG_MAX_RETRY_TIME_SEC,
           DEFAULT_KAFKA_ADMIN_GET_TOPIC_CONFIG_RETRY_IN_SECONDS);
     }
+
+    LOGGER.info(
+        "Created ApacheKafkaAdminConfig with properties: {}",
+        adminProperties,
+        new Exception().fillInStackTrace());
   }
 
   public Properties getAdminProperties() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/admin/ApacheKafkaAdminConfig.java
@@ -38,10 +38,6 @@ public class ApacheKafkaAdminConfig {
           DEFAULT_KAFKA_ADMIN_GET_TOPIC_CONFIG_RETRY_IN_SECONDS);
     }
 
-    LOGGER.info(
-        "Created ApacheKafkaAdminConfig with properties: {}",
-        adminProperties,
-        new Exception().fillInStackTrace());
   }
 
   public Properties getAdminProperties() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
@@ -243,5 +243,12 @@ public class ApacheKafkaProducerConfig {
         properties.put("kafka.security.protocol", securityProtocol);
       }
     }
+
+    LOGGER.info(
+        "copyKafkaSASLProperties skipPrefix={} configuration={} " + "finalProperties={}",
+        stripPrefix,
+        configuration,
+        properties,
+        new Exception().fillInStackTrace());
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/pubsub/adapter/kafka/producer/ApacheKafkaProducerConfig.java
@@ -244,11 +244,5 @@ public class ApacheKafkaProducerConfig {
       }
     }
 
-    LOGGER.info(
-        "copyKafkaSASLProperties skipPrefix={} configuration={} " + "finalProperties={}",
-        stripPrefix,
-        configuration,
-        properties,
-        new Exception().fillInStackTrace());
   }
 }

--- a/tests/venice-pulsar-test/src/pulsarintegrationtest/java/com/linkedin/venice/pulsar/sink/PulsarVeniceSinkTest.java
+++ b/tests/venice-pulsar-test/src/pulsarintegrationtest/java/com/linkedin/venice/pulsar/sink/PulsarVeniceSinkTest.java
@@ -166,10 +166,7 @@ public class PulsarVeniceSinkTest {
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdXBlcnVzZXIifQ.JQpDWJ9oHD743ZyuIw55Qp0bb8xzP6gK0KIWRniF2WnJB1m3v5MsrpfMlmRIlFc3-htWRAFHCc4E0ipj7JU8HjBqLIvVErRseRG-UTM1EprVkj0mk37jXV3ef7gER0KHn9CUKEQPfmTACeKlQ2oV4_qPAZ6HiEt51vzANfZH24vLCIjiOG77Z4s_w2sfgpiodRmhBLFOg_qnQTfGs7TBDWgu4DRoJ6CYZSEcp8q7j8xp_zNVIFGTRjWskocUvedHS9ZsCGZjzuPvRPp19B0VvAjEjtwpa6j7Khvjf4imjp2QHDnZwpCIEp4DSicwM48F5q4k722IdiyTTsVBWy8Cyg";
 
     String sinkConfig = "{\"veniceDiscoveryUrl\":\"" + veniceControllerUrl + "\"," + "\"veniceRouterUrl\":\""
-        + veniceRouterUrl + "\"," + "\"storeName\":\"t1_n1_s1\","
-        + "\"kafkaSaslMechanism\":\"PLAIN\",\"kafkaSecurityProtocol\":\"SASL_PLAINTEXT\","
-        + "\"kafkaSaslConfig\":\"org.apache.kafka.common.security.plain.PlainLoginModule "
-        + "required username=\\\"public\\\" password=\\\"token: " + token + "\\\"\\\";\\\");\"}";
+        + veniceRouterUrl + "\"," + "\"storeName\":\"t1_n1_s1\"}";
 
     ExecResult createSinkRes = execByServiceAsssertNoStdErr(
         "proxy",


### PR DESCRIPTION
- Fix Venice Server loading Kafka SASL parameters
- Remove JAAS configuration from PulsarSink tests, Kafka is not configured with SASL
- Add a generic `writerConfig` to tune the PulsarSink