### PR TITLE
[router][client][samza][pulsar-sink] Implement JWT token authentication on the Router service and in the Java Client

### DIFF
--- a/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
+++ b/clients/venice-admin-tool/src/main/java/com/linkedin/venice/AdminTool.java
@@ -600,11 +600,12 @@ public class AdminTool {
   private static void queryStoreForKey(CommandLine cmd, String veniceUrl) throws Exception {
     String store = getRequiredArgument(cmd, Arg.STORE);
     String keyString = getRequiredArgument(cmd, Arg.KEY);
+    String token = getOptionalArgument(cmd, Arg.TOKEN);
     String sslConfigFileStr = getOptionalArgument(cmd, Arg.VENICE_CLIENT_SSL_CONFIG_FILE);
     boolean isVsonStore = Boolean.parseBoolean(getOptionalArgument(cmd, Arg.VSON_STORE, "false"));
     Optional<String> sslConfigFile =
         StringUtils.isEmpty(sslConfigFileStr) ? Optional.empty() : Optional.of(sslConfigFileStr);
-    printObject(QueryTool.queryStoreForKey(store, keyString, veniceUrl, isVsonStore, sslConfigFile));
+    printObject(QueryTool.queryStoreForKey(store, keyString, veniceUrl, isVsonStore, sslConfigFile, token));
   }
 
   private static void showSchemas(CommandLine cmd) {

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -68,6 +68,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final D2Client d2Client;
   private final String clusterDiscoveryD2Service;
 
+  private final String token;
+
   private ClientConfig(
       String storeName,
       Client r2Client,
@@ -95,13 +97,15 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       boolean isVsonStore,
       boolean isRequestBasedMetadata,
       D2Client d2Client,
-      String clusterDiscoveryD2Service) {
+      String clusterDiscoveryD2Service,
+      String token) {
     if (storeName == null || storeName.isEmpty()) {
       throw new VeniceClientException("storeName param shouldn't be empty");
     }
     if (r2Client == null) {
       throw new VeniceClientException("r2Client param shouldn't be null");
     }
+    this.token = token;
     this.r2Client = r2Client;
     this.storeName = storeName;
     this.statsPrefix = (statsPrefix == null ? "" : statsPrefix);
@@ -310,6 +314,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return this.clusterDiscoveryD2Service;
   }
 
+  public String getToken() {
+    return token;
+  }
+
   public static class ClientConfigBuilder<K, V, T extends SpecificRecord> {
     private MetricsRepository metricsRepository;
     private String statsPrefix = "";
@@ -354,6 +362,12 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private boolean isRequestBasedMetadata = false;
     private D2Client d2Client;
     private String clusterDiscoveryD2Service;
+    private String token;
+
+    public ClientConfigBuilder<K, V, T> setToken(String token) {
+      this.token = token;
+      return this;
+    }
 
     public ClientConfigBuilder<K, V, T> setStoreName(String storeName) {
       this.storeName = storeName;
@@ -501,6 +515,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
     public ClientConfigBuilder<K, V, T> clone() {
       return new ClientConfigBuilder().setStoreName(storeName)
+          .setToken(token)
           .setR2Client(r2Client)
           .setMetricsRepository(metricsRepository)
           .setStatsPrefix(statsPrefix)
@@ -557,7 +572,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           isVsonStore,
           isRequestBasedMetadata,
           d2Client,
-          clusterDiscoveryD2Service);
+          clusterDiscoveryD2Service,
+          token);
     }
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/DispatchingAvroGenericStoreClient.java
@@ -66,10 +66,12 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   // Key serializer
   private RecordSerializer<K> keySerializer;
   private RecordSerializer<MultiGetRouterRequestKeyV1> multiGetSerializer;
+  private final String token;
 
   public DispatchingAvroGenericStoreClient(StoreMetadata metadata, ClientConfig config) {
     this.metadata = metadata;
     this.config = config;
+    this.token = config.getToken();
     this.transportClient = new R2TransportClient(config.getR2Client());
 
     if (config.isSpeculativeQueryEnabled()) {
@@ -194,7 +196,13 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       requestContext.routeRequestMap.put(route, routeRequestFuture);
       try {
         String url = route + uri;
-        CompletableFuture<TransportClientResponse> transportFuture = transportClient.get(url);
+        Map<String, String> headers;
+        if (token != null && !token.isEmpty()) {
+          headers = Collections.singletonMap("Authorization", "Bearer " + token);
+        } else {
+          headers = Collections.emptyMap();
+        }
+        CompletableFuture<TransportClientResponse> transportFuture = transportClient.get(url, headers);
         transportFutures.add(transportFuture);
         transportFuture.whenCompleteAsync((response, throwable) -> {
           if (throwable != null) {
@@ -440,6 +448,9 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
       headers.put(
           HttpConstants.VENICE_API_VERSION,
           Integer.toString(ReadAvroProtocolDefinition.MULTI_GET_ROUTER_REQUEST_V1.getProtocolVersion()));
+      if (token != null && !token.isEmpty()) {
+        headers.put("Authorization", "Bearer " + token);
+      }
       long tsBeforeSerialization = System.nanoTime();
       byte[] serializedKeys = serializeMultiGetRequest(requestContext.keysForRoutes(route));
       requestContext.recordRequestSerializationTime(route, getLatencyInNS(tsBeforeSerialization));
@@ -642,5 +653,4 @@ public class DispatchingAvroGenericStoreClient<K, V> extends InternalAvroStoreCl
   public Schema getLatestValueSchema() {
     return metadata.getLatestValueSchema();
   }
-
 }

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.fastclient;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
@@ -87,5 +88,13 @@ public class ClientConfigTest {
         .setLongTailRetryEnabledForSingleGet(true)
         .setLongTailRetryThresholdForSingleGetInMicroSeconds(1000)
         .build();
+  }
+
+  @Test
+  public void testClientWithToken() {
+    ClientConfig.ClientConfigBuilder clientConfigBuilder =
+        getClientConfigWithMinimumRequiredInputs().setToken("test_token");
+
+    assertEquals("test_token", clientConfigBuilder.build().getToken());
   }
 }

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSink.java
@@ -9,6 +9,7 @@ import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_CONTROLLER_DI
 import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_PUSH_TYPE;
 import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_ROUTER_URL;
 import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_STORE;
+import static com.linkedin.venice.samza.VeniceSystemFactory.VENICE_TOKEN;
 
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.samza.VeniceSystemFactory;
@@ -246,6 +247,11 @@ public class VeniceSink implements Sink<GenericObject> {
     if (veniceCfg.getWriterConfig() != null && !veniceCfg.getWriterConfig().isEmpty()) {
       LOGGER.info("Additional WriterConfig: {}", veniceCfg.getWriterConfig());
       config.putAll(veniceCfg.getWriterConfig());
+    }
+
+    if (veniceCfg.getVeniceToken() != null && !veniceCfg.getVeniceToken().isEmpty()) {
+      LOGGER.info("VeniceToken: {}", veniceCfg.getVeniceToken());
+      config.put(VENICE_TOKEN, veniceCfg.getVeniceToken());
     }
 
     LOGGER.info("CONFIG: {}", config);

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSinkConfig.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VeniceSinkConfig.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.pulsar.io.common.IOConfigUtils;
@@ -42,6 +43,9 @@ public class VeniceSinkConfig implements Serializable {
 
   @FieldDoc(defaultValue = "", help = "The url of the Venice router")
   private String veniceRouterUrl = "http://venice-router:7777";
+
+  @FieldDoc(defaultValue = "", help = "JWT Token for Venice")
+  private String veniceToken = "";
 
   @FieldDoc(defaultValue = "", help = "SASL configuration for Kafka. See Kafka client documentation for details.")
   private String kafkaSaslConfig = "";
@@ -82,6 +86,11 @@ public class VeniceSinkConfig implements Serializable {
   @java.lang.SuppressWarnings("all")
   public String getVeniceRouterUrl() {
     return this.veniceRouterUrl;
+  }
+
+  @java.lang.SuppressWarnings("all")
+  public String getVeniceToken() {
+    return this.veniceToken;
   }
 
   @java.lang.SuppressWarnings("all")
@@ -168,6 +177,15 @@ public class VeniceSinkConfig implements Serializable {
    * @return {@code this}.
    */
   @java.lang.SuppressWarnings("all")
+  public VeniceSinkConfig setVeniceToken(String veniceToken) {
+    this.veniceToken = veniceToken;
+    return this;
+  }
+
+  /**
+   * @return {@code this}.
+   */
+  @java.lang.SuppressWarnings("all")
   public VeniceSinkConfig setStoreName(final String storeName) {
     this.storeName = storeName;
     return this;
@@ -196,89 +214,35 @@ public class VeniceSinkConfig implements Serializable {
     this.writerConfig = writerConfig;
   }
 
-  @java.lang.Override
-  @java.lang.SuppressWarnings("all")
-  public boolean equals(final java.lang.Object o) {
-    if (o == this)
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
       return true;
-    if (!(o instanceof VeniceSinkConfig))
+    if (o == null || getClass() != o.getClass())
       return false;
-    final VeniceSinkConfig other = (VeniceSinkConfig) o;
-    if (!other.canEqual((java.lang.Object) this))
-      return false;
-    if (this.getFlushIntervalMs() != other.getFlushIntervalMs())
-      return false;
-    if (this.getMaxNumberUnflushedRecords() != other.getMaxNumberUnflushedRecords())
-      return false;
-    final java.lang.Object this$veniceDiscoveryUrl = this.getVeniceDiscoveryUrl();
-    final java.lang.Object other$veniceDiscoveryUrl = other.getVeniceDiscoveryUrl();
-    if (this$veniceDiscoveryUrl == null
-        ? other$veniceDiscoveryUrl != null
-        : !this$veniceDiscoveryUrl.equals(other$veniceDiscoveryUrl))
-      return false;
-    final java.lang.Object this$veniceRouterUrl = this.getVeniceRouterUrl();
-    final java.lang.Object other$veniceRouterUrl = other.getVeniceRouterUrl();
-    if (this$veniceRouterUrl == null
-        ? other$veniceRouterUrl != null
-        : !this$veniceRouterUrl.equals(other$veniceRouterUrl))
-      return false;
-    final java.lang.Object this$writerConfig = this.getWriterConfig();
-    final java.lang.Object other$writerConfig = other.getWriterConfig();
-    if (this$writerConfig == null ? other$writerConfig != null : !this$writerConfig.equals(other$writerConfig))
-      return false;
-    final java.lang.Object this$kafkaSaslConfig = this.getKafkaSaslConfig();
-    final java.lang.Object other$kafkaSaslConfig = other.getKafkaSaslConfig();
-    if (this$kafkaSaslConfig == null
-        ? other$kafkaSaslConfig != null
-        : !this$kafkaSaslConfig.equals(other$kafkaSaslConfig))
-      return false;
-    final java.lang.Object this$kafkaSaslMechanism = this.getKafkaSaslMechanism();
-    final java.lang.Object other$kafkaSaslMechanism = other.getKafkaSaslMechanism();
-    if (this$kafkaSaslMechanism == null
-        ? other$kafkaSaslMechanism != null
-        : !this$kafkaSaslMechanism.equals(other$kafkaSaslMechanism))
-      return false;
-    final java.lang.Object this$kafkaSecurityProtocol = this.getKafkaSecurityProtocol();
-    final java.lang.Object other$kafkaSecurityProtocol = other.getKafkaSecurityProtocol();
-    if (this$kafkaSecurityProtocol == null
-        ? other$kafkaSecurityProtocol != null
-        : !this$kafkaSecurityProtocol.equals(other$kafkaSecurityProtocol))
-      return false;
-    final java.lang.Object this$storeName = this.getStoreName();
-    final java.lang.Object other$storeName = other.getStoreName();
-    if (this$storeName == null ? other$storeName != null : !this$storeName.equals(other$storeName))
-      return false;
-    return true;
+    VeniceSinkConfig that = (VeniceSinkConfig) o;
+    return flushIntervalMs == that.flushIntervalMs && maxNumberUnflushedRecords == that.maxNumberUnflushedRecords
+        && Objects.equals(veniceDiscoveryUrl, that.veniceDiscoveryUrl)
+        && Objects.equals(veniceRouterUrl, that.veniceRouterUrl) && Objects.equals(veniceToken, that.veniceToken)
+        && Objects.equals(kafkaSaslConfig, that.kafkaSaslConfig)
+        && Objects.equals(kafkaSaslMechanism, that.kafkaSaslMechanism)
+        && Objects.equals(kafkaSecurityProtocol, that.kafkaSecurityProtocol)
+        && Objects.equals(storeName, that.storeName) && Objects.equals(writerConfig, that.writerConfig);
   }
 
-  @java.lang.SuppressWarnings("all")
-  protected boolean canEqual(final java.lang.Object other) {
-    return other instanceof VeniceSinkConfig;
-  }
-
-  @java.lang.Override
-  @java.lang.SuppressWarnings("all")
+  @Override
   public int hashCode() {
-    final int PRIME = 59;
-    int result = 1;
-    final long $flushIntervalMs = this.getFlushIntervalMs();
-    result = result * PRIME + (int) ($flushIntervalMs >>> 32 ^ $flushIntervalMs);
-    result = result * PRIME + this.getMaxNumberUnflushedRecords();
-    final java.lang.Object $veniceDiscoveryUrl = this.getVeniceDiscoveryUrl();
-    result = result * PRIME + ($veniceDiscoveryUrl == null ? 43 : $veniceDiscoveryUrl.hashCode());
-    final java.lang.Object $veniceRouterUrl = this.getVeniceRouterUrl();
-    result = result * PRIME + ($veniceRouterUrl == null ? 43 : $veniceRouterUrl.hashCode());
-    final java.lang.Object $kafkaSaslConfig = this.getKafkaSaslConfig();
-    result = result * PRIME + ($kafkaSaslConfig == null ? 43 : $kafkaSaslConfig.hashCode());
-    final java.lang.Object $kafkaSaslMechanism = this.getKafkaSaslMechanism();
-    result = result * PRIME + ($kafkaSaslMechanism == null ? 43 : $kafkaSaslMechanism.hashCode());
-    final java.lang.Object $kafkaSecurityProtocol = this.getKafkaSecurityProtocol();
-    result = result * PRIME + ($kafkaSecurityProtocol == null ? 43 : $kafkaSecurityProtocol.hashCode());
-    final java.lang.Object $storeName = this.getStoreName();
-    result = result * PRIME + ($storeName == null ? 43 : $storeName.hashCode());
-    final java.lang.Object $writerConfig = this.getWriterConfig();
-    result = result * PRIME + ($writerConfig == null ? 43 : $writerConfig.hashCode());
-    return result;
+    return Objects.hash(
+        veniceDiscoveryUrl,
+        veniceRouterUrl,
+        veniceToken,
+        kafkaSaslConfig,
+        kafkaSaslMechanism,
+        kafkaSecurityProtocol,
+        storeName,
+        flushIntervalMs,
+        maxNumberUnflushedRecords,
+        writerConfig);
   }
 
   @java.lang.Override

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
@@ -95,6 +95,11 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
    */
   public static final String VENICE_PARENT_D2_ZK_HOSTS = "venice.parent.d2.zk.hosts";
 
+  /**
+   * JWT token authentication against Venice services.
+   */
+  public static final String VENICE_TOKEN = "venice.authentication.token";
+
   // D2 service name for local cluster
   public static final String VENICE_CHILD_CONTROLLER_D2_SERVICE = "venice.child.controller.d2.service";
   // D2 service name for parent cluster
@@ -374,6 +379,7 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
           SystemTime.INSTANCE);
       p.setRouterUrl(routerUrl);
       p.applyAdditionalWriterConfigs(config);
+      p.setToken(config.get(VENICE_TOKEN, null));
       return p;
     }
 
@@ -445,6 +451,7 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
         sslFactory,
         partitioners);
     systemProducer.applyAdditionalWriterConfigs(config);
+    systemProducer.setToken(config.get(VENICE_TOKEN, null));
     this.systemProducerStatues.computeIfAbsent(systemProducer, k -> Pair.create(true, false));
     return systemProducer;
   }

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
@@ -365,6 +365,7 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
       LOGGER.info("{}{}: {}", prefix, VENICE_PUSH_TYPE, venicePushType);
       LOGGER.info("{}: {}", VENICE_CONTROLLER_DISCOVERY_URL, discoveryUrl.get());
       LOGGER.info("{}: {}", VENICE_ROUTER_URL, routerUrl);
+      LOGGER.info("{}: {}", VENICE_TOKEN, config.get(VENICE_TOKEN, null));
 
       VeniceSystemProducer p = new VeniceSystemProducer(
           discoveryUrl.get(),
@@ -422,6 +423,7 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
     LOGGER.info("{}: {}", VENICE_CHILD_D2_ZK_HOSTS, localVeniceZKHosts);
     LOGGER.info("{}: {}", VENICE_PARENT_CONTROLLER_D2_SERVICE, parentControllerD2Service);
     LOGGER.info("{}: {}", VENICE_CHILD_CONTROLLER_D2_SERVICE, localControllerD2Service);
+    LOGGER.info("{}: {}", VENICE_TOKEN, config.get(VENICE_TOKEN, null));
 
     String primaryControllerColoD2ZKHost;
     String primaryControllerD2Service;

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -157,6 +157,8 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
   private Optional<String> discoveryUrl = Optional.empty();
   private Optional<String> routerUrl = Optional.empty();
 
+  private String token;
+
   private VeniceWriter<byte[], byte[], byte[]> veniceWriter = null;
   private Optional<RouterBasedPushMonitor> pushMonitor = Optional.empty();
   private Optional<RouterBasedHybridStoreQuotaMonitor> hybridStoreQuotaMonitor = Optional.empty();
@@ -326,6 +328,10 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     this.additionalWriterConfigs.putAll(additionalWriterConfigs);
   }
 
+  public void setToken(String token) {
+    this.token = token;
+  }
+
   public void setRouterUrl(String routerUrl) {
     this.routerUrl = Optional.of(routerUrl);
   }
@@ -450,9 +456,9 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
       }
 
       if (sslFactory.isPresent()) {
-        transportClient = new HttpsTransportClient(discoveryUrl.get(), sslFactory.get());
+        transportClient = new HttpsTransportClient(discoveryUrl.get(), sslFactory.get(), token);
       } else {
-        transportClient = new HttpTransportClient(discoveryUrl.get());
+        transportClient = new HttpTransportClient(discoveryUrl.get(), token);
       }
     } else {
       this.primaryControllerColoD2Client = getStartedD2Client(primaryControllerColoD2ZKHost);

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemProducer.java
@@ -432,7 +432,7 @@ public class VeniceSystemProducer implements SystemProducer, Closeable {
     final TransportClient transportClient;
     if (discoveryUrl.isPresent()) {
       this.controllerClient =
-          ControllerClient.discoverAndConstructControllerClient(storeName, discoveryUrl.get(), sslFactory, 1);
+          ControllerClient.discoverAndConstructControllerClient(storeName, discoveryUrl.get(), sslFactory, 1, token);
 
       /**
        * Verify that the latest {@link com.linkedin.venice.serialization.avro.AvroProtocolDefinition#KAFKA_MESSAGE_ENVELOPE}

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -62,6 +62,8 @@ public class ClientConfig<T extends SpecificRecord> {
   // Test settings
   private Time time = new SystemTime();
 
+  private String token;
+
   public static ClientConfig defaultGenericClientConfig(String storeName) {
     return new ClientConfig(storeName);
   }
@@ -106,6 +108,7 @@ public class ClientConfig<T extends SpecificRecord> {
         // Security settings
         .setHttps(config.isHttps())
         .setSslFactory(config.getSslFactory())
+        .setToken(config.getToken())
 
         .setForceClusterDiscoveryAtStartTime(config.isForceClusterDiscoveryAtStartTime())
         .setProjectionFieldValidationEnabled(config.isProjectionFieldValidationEnabled())
@@ -251,6 +254,15 @@ public class ClientConfig<T extends SpecificRecord> {
 
   public ClientConfig<T> setSslFactory(SSLFactory sslEngineComponentFactory) {
     this.sslFactory = sslEngineComponentFactory;
+    return this;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  public ClientConfig<T> setToken(String token) {
+    this.token = token;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -121,9 +121,9 @@ public class ClientFactory {
         throw new VeniceClientException("Must use SSL factory method for client to communicate with https");
       }
 
-      return new HttpsTransportClient(bootstrapUrl, clientConfig.getSslFactory());
+      return new HttpsTransportClient(bootstrapUrl, clientConfig.getSslFactory(), clientConfig.getToken());
     } else {
-      return new HttpTransportClient(bootstrapUrl);
+      return new HttpTransportClient(bootstrapUrl, clientConfig.getToken());
     }
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/QueryTool.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/QueryTool.java
@@ -59,9 +59,6 @@ public class QueryTool {
       boolean isVsonStore,
       Optional<String> sslConfigFile,
       String token) throws Exception {
-    System.out.println(
-        "queryStoreForKey: store=" + store + ", keyString=" + keyString + ", url=" + url + ", isVsonStore="
-            + isVsonStore + ", sslConfigFile=" + sslConfigFile + ", token=" + token);
 
     SSLFactory factory = null;
     if (sslConfigFile.isPresent()) {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/QueryTool.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/QueryTool.java
@@ -29,12 +29,13 @@ public class QueryTool {
   private static final int URL = 2;
   private static final int IS_VSON_STORE = 3;
   private static final int SSL_CONFIG_FILE_PATH = 4;
+  private static final int TOKEN = 5; // not required
   private static final int REQUIRED_ARGS_COUNT = 5;
 
   public static void main(String[] args) throws Exception {
     if (args.length < REQUIRED_ARGS_COUNT) {
       System.out.println(
-          "Usage: java -jar venice-thin-client-0.1.jar <store> <key_string> <url> <is_vson_store> <ssl_config_file_path>");
+          "Usage: java -jar venice-thin-client-0.1.jar <store> <key_string> <url> <is_vson_store> <ssl_config_file_path> <token>");
       System.exit(1);
     }
     String store = removeQuotes(args[STORE]);
@@ -42,11 +43,12 @@ public class QueryTool {
     String url = removeQuotes(args[URL]);
     boolean isVsonStore = Boolean.parseBoolean(removeQuotes(args[IS_VSON_STORE]));
     String sslConfigFilePath = removeQuotes(args[SSL_CONFIG_FILE_PATH]);
+    String token = args.length > TOKEN ? removeQuotes(args[TOKEN]) : null;
     Optional<String> sslConfigFilePathArgs =
         StringUtils.isEmpty(sslConfigFilePath) ? Optional.empty() : Optional.of(sslConfigFilePath);
     System.out.println();
 
-    Map<String, String> outputMap = queryStoreForKey(store, keyString, url, isVsonStore, sslConfigFilePathArgs);
+    Map<String, String> outputMap = queryStoreForKey(store, keyString, url, isVsonStore, sslConfigFilePathArgs, token);
     outputMap.entrySet().stream().forEach(System.out::println);
   }
 
@@ -55,7 +57,11 @@ public class QueryTool {
       String keyString,
       String url,
       boolean isVsonStore,
-      Optional<String> sslConfigFile) throws Exception {
+      Optional<String> sslConfigFile,
+      String token) throws Exception {
+    System.out.println(
+        "queryStoreForKey: store=" + store + ", keyString=" + keyString + ", url=" + url + ", isVsonStore="
+            + isVsonStore + ", sslConfigFile=" + sslConfigFile + ", token=" + token);
 
     SSLFactory factory = null;
     if (sslConfigFile.isPresent()) {
@@ -73,6 +79,7 @@ public class QueryTool {
     try (AvroGenericStoreClient<Object, Object> client = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(store)
             .setVeniceURL(url)
+            .setToken(token)
             .setVsonClient(isVsonStore)
             .setSslFactory(factory))) {
       AbstractAvroStoreClient<Object, Object> castClient =

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/D2TransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/D2TransportClient.java
@@ -259,7 +259,7 @@ public class D2TransportClient extends TransportClient {
   }
 
   private Map<String, String> injectSecurityHeaders(Map<String, String> headers) {
-    if (token != null & !token.isEmpty()) {
+    if (token != null && !token.isEmpty()) {
       if (headers == null) {
         return Collections.singletonMap("Authorization", "Bearer " + token);
       } else {

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpTransportClient.java
@@ -35,14 +35,16 @@ public class HttpTransportClient extends TransportClient {
   // Example: 'http://router-host:80/'
   protected final String routerUrl;
   private final CloseableHttpAsyncClient httpClient;
+  protected final String token;
 
-  public HttpTransportClient(String routerUrl) {
-    this(routerUrl, HttpAsyncClients.createDefault());
+  public HttpTransportClient(String routerUrl, String token) {
+    this(routerUrl, HttpAsyncClients.createDefault(), token);
   }
 
-  public HttpTransportClient(String routerUrl, CloseableHttpAsyncClient httpClient) {
+  public HttpTransportClient(String routerUrl, CloseableHttpAsyncClient httpClient, String token) {
     this.routerUrl = ensureTrailingSlash(routerUrl);
     this.httpClient = httpClient;
+    this.token = token;
     httpClient.start();
   }
 
@@ -109,6 +111,9 @@ public class HttpTransportClient extends TransportClient {
     headers.forEach((K, V) -> {
       httpGet.addHeader(K, V);
     });
+    if (token != null && !token.isEmpty()) {
+      httpGet.addHeader("Authorization", "Bearer " + token);
+    }
     return httpGet;
   }
 
@@ -117,6 +122,9 @@ public class HttpTransportClient extends TransportClient {
     headers.forEach((K, V) -> {
       httpPost.setHeader(K, V);
     });
+    if (token != null && !token.isEmpty()) {
+      httpPost.addHeader("Authorization", "Bearer " + token);
+    }
     BasicHttpEntity entity = new BasicHttpEntity();
     entity.setContent(new ByteArrayInputStream(body));
     httpPost.setEntity(entity);
@@ -140,7 +148,7 @@ public class HttpTransportClient extends TransportClient {
    */
   @Override
   public TransportClient getCopyIfNotUsableInCallback() {
-    return new HttpTransportClient(routerUrl);
+    return new HttpTransportClient(routerUrl, token);
   }
 
   private static class HttpTransportClientCallback extends TransportClientCallback

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
@@ -10,15 +10,16 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 public class HttpsTransportClient extends HttpTransportClient {
   private SSLFactory sslFactory;
 
-  public HttpsTransportClient(String routerUrl, SSLFactory sslFactory) {
+  public HttpsTransportClient(String routerUrl, SSLFactory sslFactory, String token) {
     this(
         routerUrl,
-        HttpAsyncClients.custom().setSSLStrategy(new SSLIOSessionStrategy(sslFactory.getSSLContext())).build());
+        HttpAsyncClients.custom().setSSLStrategy(new SSLIOSessionStrategy(sslFactory.getSSLContext())).build(),
+        token);
     this.sslFactory = sslFactory;
   }
 
-  public HttpsTransportClient(String routerUrl, CloseableHttpAsyncClient client) {
-    super(routerUrl, client);
+  public HttpsTransportClient(String routerUrl, CloseableHttpAsyncClient client, String token) {
+    super(routerUrl, client, token);
     if (!routerUrl.startsWith(HTTPS)) {
       throw new VeniceException("Must use https url with HttpsTransportClient, found: " + routerUrl);
     }
@@ -30,6 +31,6 @@ public class HttpsTransportClient extends HttpTransportClient {
    */
   @Override
   public TransportClient getCopyIfNotUsableInCallback() {
-    return new HttpsTransportClient(routerUrl, sslFactory);
+    return new HttpsTransportClient(routerUrl, sslFactory, token);
   }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestTransportClient.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestTransportClient.java
@@ -46,7 +46,7 @@ public class TestTransportClient {
     d2TransportClient = new D2TransportClient(SERVICE_NAME, mockD2Client);
 
     mockHttpClient = mock(CloseableHttpAsyncClient.class);
-    httpTransportClient = new HttpTransportClient(HTTP_PREFIX + SERVICE_NAME, mockHttpClient);
+    httpTransportClient = new HttpTransportClient(HTTP_PREFIX + SERVICE_NAME, mockHttpClient, null);
   }
 
   @AfterMethod

--- a/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/ConfigKeys.java
@@ -30,6 +30,9 @@ public class ConfigKeys {
   // store specific properties
   public static final String PERSISTENCE_TYPE = "persistence.type";
 
+  public static final String AUTHENTICATION_SERVICE_CLASS = "authentication.service.class";
+  public static final String AUTHORIZER_SERVICE_CLASS = "authorizer.service.class";
+
   public static final String KAFKA_CONFIG_PREFIX = ApacheKafkaProducerConfig.KAFKA_CONFIG_PREFIX;
   public static final String KAFKA_BOOTSTRAP_SERVERS = ApacheKafkaProducerConfig.KAFKA_BOOTSTRAP_SERVERS;
   public static final String SSL_KAFKA_BOOTSTRAP_SERVERS = ApacheKafkaProducerConfig.SSL_KAFKA_BOOTSTRAP_SERVERS;

--- a/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/acl/handler/StoreAclHandler.java
@@ -3,21 +3,31 @@ package com.linkedin.venice.acl.handler;
 import com.linkedin.venice.acl.AclCreationDeletionListener;
 import com.linkedin.venice.acl.AclException;
 import com.linkedin.venice.acl.DynamicAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
+import com.linkedin.venice.authorization.Method;
+import com.linkedin.venice.authorization.Principal;
+import com.linkedin.venice.authorization.Resource;
 import com.linkedin.venice.exceptions.VeniceNoStoreException;
 import com.linkedin.venice.meta.QueryAction;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Store;
 import com.linkedin.venice.utils.NettyUtils;
 import com.linkedin.venice.utils.SslUtils;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import org.apache.logging.log4j.LogManager;
@@ -32,13 +42,26 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
   private static final Logger LOGGER = LogManager.getLogger(StoreAclHandler.class);
 
   private final ReadOnlyStoreRepository metadataRepository;
-  private final DynamicAccessController accessController;
+  private final Optional<DynamicAccessController> accessController;
 
-  public StoreAclHandler(DynamicAccessController accessController, ReadOnlyStoreRepository metadataRepository) {
+  private final Optional<AuthenticationService> authenticationService;
+  private final Optional<AuthorizerService> authorizerService;
+
+  public StoreAclHandler(
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
+      ReadOnlyStoreRepository metadataRepository) {
     this.metadataRepository = metadataRepository;
+
     this.accessController = accessController
-        .init(metadataRepository.getAllStores().stream().map(Store::getName).collect(Collectors.toList()));
-    this.metadataRepository.registerStoreDataChangedListener(new AclCreationDeletionListener(accessController));
+        .map(a -> a.init(metadataRepository.getAllStores().stream().map(Store::getName).collect(Collectors.toList())));
+
+    this.authenticationService = authenticationService;
+    this.authorizerService = authorizerService;
+    if (accessController.isPresent()) {
+      this.metadataRepository.registerStoreDataChangedListener(new AclCreationDeletionListener(accessController.get()));
+    }
   }
 
   /**
@@ -56,8 +79,15 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
        */
       sslHandler = ctx.channel().parent().pipeline().get(SslHandler.class);
     }
+    if (sslHandler == null) {
+      return null;
+    }
     return SslUtils.getX509Certificate(sslHandler.engine().getSession().getPeerCertificates()[0]);
   }
+
+  private static AttributeKey<Principal> PRINCIPAL_ATTR = AttributeKey.valueOf("principal");
+  private static AttributeKey<String> FIRST_AUTHORIZATION_ATTRIBUTE =
+      AttributeKey.valueOf("first_authorization_attribute");
 
   /**
    * Verify if client has permission to access.
@@ -69,6 +99,7 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
   @Override
   public void channelRead0(ChannelHandlerContext ctx, HttpRequest req) throws SSLPeerUnverifiedException {
     X509Certificate clientCert = extractClientCert(ctx);
+    Principal principal = getPrincipal(ctx, req, clientCert);
 
     String uri = req.uri();
     // Parse resource type and store name
@@ -101,7 +132,30 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
         ctx.fireChannelRead(req);
       } else {
         try {
-          if (accessController.hasAccess(clientCert, storeName, method)) {
+          if (!accessController.isPresent() && !authenticationService.isPresent()) {
+            // no security, proceed
+            ReferenceCountUtil.retain(req);
+            ctx.fireChannelRead(req);
+          } else if (authorizerService.isPresent()) {
+            boolean granted = true;
+            if (authorizerService.isPresent()) {
+              granted = authorizerService.get().canAccess(Method.valueOf(method), new Resource(storeName), principal);
+              if (!granted) {
+                LOGGER.info("Principal {} is denied to access {} {}", principal, method, storeName);
+              }
+            }
+            if (!granted) {
+              NettyUtils.setupResponseAndFlush(
+                  HttpResponseStatus.UNAUTHORIZED,
+                  "Authentication required".getBytes(StandardCharsets.UTF_8),
+                  false,
+                  ctx);
+            } else {
+              // Client has permission. Proceed
+              ReferenceCountUtil.retain(req);
+              ctx.fireChannelRead(req);
+            }
+          } else if ((accessController.get().hasAccess(clientCert, storeName, method))) {
             // Client has permission. Proceed
             ReferenceCountUtil.retain(req);
             ctx.fireChannelRead(req);
@@ -115,7 +169,8 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
             String client = ctx.channel().remoteAddress().toString(); // ip and port
             String errLine = String.format("%s requested %s %s", client, method, req.uri());
 
-            if (!accessController.isFailOpen() && !accessController.hasAcl(storeName)) { // short circuit, order matters
+            if (!accessController.get().isFailOpen() && !accessController.get().hasAcl(storeName)) { // short circuit,
+                                                                                                     // order matters
               // Case A
               // Conditions:
               // 0. (outside) Store exists and is being access controlled. AND,
@@ -137,7 +192,11 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
                       .collect(Collectors.toList()));
               LOGGER.debug(
                   "Access-controlled stores: {}",
-                  () -> accessController.getAccessControlledResources().stream().sorted().collect(Collectors.toList()));
+                  () -> accessController.get()
+                      .getAccessControlledResources()
+                      .stream()
+                      .sorted()
+                      .collect(Collectors.toList()));
               NettyUtils.setupResponseAndFlush(
                   HttpResponseStatus.UNAUTHORIZED,
                   ("ACL not found!\n" + "Either it has not been created, or can not be loaded.\n"
@@ -177,7 +236,7 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
           String client = ctx.channel().remoteAddress().toString(); // ip and port
           String errLine = String.format("%s requested %s %s", client, method, req.uri());
 
-          if (accessController.isFailOpen()) {
+          if (accessController.get().isFailOpen()) {
             LOGGER.warn("Exception occurred! Access granted: {} {}", errLine, e);
             ReferenceCountUtil.retain(req);
             ctx.fireChannelRead(req);
@@ -196,5 +255,38 @@ public class StoreAclHandler extends SimpleChannelInboundHandler<HttpRequest> {
           false,
           ctx);
     }
+  }
+
+  private Principal getPrincipal(ChannelHandlerContext ctx, HttpRequest req, X509Certificate clientCert) {
+    Principal principal = null;
+    if (authenticationService.isPresent()) {
+      // here we are assuming that the Principal depends on the Authorization header
+      // this is not valid for all authentication methods, but it is valid for the ones we support
+      Channel channel = ctx.channel();
+      String authorizationHeader = req.headers().get("Authorization", "");
+      if (channel.hasAttr(PRINCIPAL_ATTR) && channel.hasAttr(FIRST_AUTHORIZATION_ATTRIBUTE)) {
+        String firstAuthorizeHeader = channel.attr(FIRST_AUTHORIZATION_ATTRIBUTE).get();
+        if (Objects.equals(firstAuthorizeHeader, authorizationHeader)) {
+          principal = channel.attr(PRINCIPAL_ATTR).get();
+        }
+      }
+      if (principal == null) {
+        principal =
+            authenticationService.get().getPrincipalFromHttpRequest(new AuthenticationService.HttpRequestAccessor() {
+              @Override
+              public String getHeader(String headerName) {
+                return req.headers().get(headerName, "");
+              }
+
+              @Override
+              public X509Certificate getCertificate() {
+                return clientCert;
+              }
+            });
+        channel.attr(PRINCIPAL_ATTR).set(principal);
+        channel.attr(FIRST_AUTHORIZATION_ATTRIBUTE).set(authorizationHeader);
+      }
+    }
+    return principal;
   }
 }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationServiceUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authentication/AuthenticationServiceUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.authentication;
 
+import static com.linkedin.venice.ConfigKeys.AUTHENTICATION_SERVICE_CLASS;
+
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -13,7 +15,7 @@ public abstract class AuthenticationServiceUtils {
   }
 
   public static Optional<AuthenticationService> buildAuthenticationService(VeniceProperties veniceProperties) {
-    String className = veniceProperties.getString("authentication.service.class", "");
+    String className = veniceProperties.getString(AUTHENTICATION_SERVICE_CLASS, "");
     if (className.isEmpty()) {
       return Optional.empty();
     }
@@ -27,6 +29,7 @@ public abstract class AuthenticationServiceUtils {
       authenticationService.initialise(veniceProperties);
       return Optional.of(authenticationService);
     } catch (Exception ex) {
+      LOGGER.error("Cannot load {}", className, ex);
       throw new IllegalStateException(ex);
     }
   }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerServiceUtils.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/authorization/AuthorizerServiceUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.authorization;
 
+import static com.linkedin.venice.ConfigKeys.AUTHORIZER_SERVICE_CLASS;
+
 import com.linkedin.venice.utils.VeniceProperties;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
@@ -13,7 +15,7 @@ public abstract class AuthorizerServiceUtils {
   }
 
   public static Optional<AuthorizerService> buildAuthorizerService(VeniceProperties veniceProperties) {
-    String className = veniceProperties.getString("authorizer.service.class", "");
+    String className = veniceProperties.getString(AUTHORIZER_SERVICE_CLASS, "");
     if (className.isEmpty()) {
       return Optional.empty();
     }

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
@@ -62,6 +62,11 @@ public class ControllerTransport implements AutoCloseable {
     if (token != null && !token.isEmpty()) {
       this.additionalHeaders.put("Authorization", "Bearer " + token);
     }
+    LOGGER.info(
+        "Created ControllerTransport with token: {} additionalHeaders {}",
+        token,
+        additionalHeaders,
+        new Exception().fillInStackTrace());
   }
 
   public static ObjectMapper getObjectMapper() {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
@@ -62,11 +62,6 @@ public class ControllerTransport implements AutoCloseable {
     if (token != null && !token.isEmpty()) {
       this.additionalHeaders.put("Authorization", "Bearer " + token);
     }
-    LOGGER.info(
-        "Created ControllerTransport with token: {} additionalHeaders {}",
-        token,
-        additionalHeaders,
-        new Exception().fillInStackTrace());
   }
 
   public static ObjectMapper getObjectMapper() {

--- a/internal/venice-common/src/test/java/com/linkedin/venice/acl/StoreAclHandlerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/acl/StoreAclHandlerTest.java
@@ -206,7 +206,8 @@ public class StoreAclHandlerTest {
       }
       // New metadataRepo mock and aclHandler every update since thenThrow cannot be re-mocked.
       metadataRepo = mock(HelixReadOnlyStoreRepository.class);
-      aclHandler = spy(new StoreAclHandler(Optional.of(accessController), Optional.empty(), Optional.empty(), metadataRepo));
+      aclHandler =
+          spy(new StoreAclHandler(Optional.of(accessController), Optional.empty(), Optional.empty(), metadataRepo));
       update();
       aclHandler.channelRead0(ctx, req);
     }

--- a/internal/venice-common/src/test/java/com/linkedin/venice/acl/StoreAclHandlerTest.java
+++ b/internal/venice-common/src/test/java/com/linkedin/venice/acl/StoreAclHandlerTest.java
@@ -24,6 +24,7 @@ import io.netty.handler.ssl.SslHandler;
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 import org.mockito.ArgumentMatcher;
@@ -205,7 +206,7 @@ public class StoreAclHandlerTest {
       }
       // New metadataRepo mock and aclHandler every update since thenThrow cannot be re-mocked.
       metadataRepo = mock(HelixReadOnlyStoreRepository.class);
-      aclHandler = spy(new StoreAclHandler(accessController, metadataRepo));
+      aclHandler = spy(new StoreAclHandler(Optional.of(accessController), Optional.empty(), Optional.empty(), metadataRepo));
       update();
       aclHandler.channelRead0(ctx, req);
     }

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/client/store/TestSslTransportClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/client/store/TestSslTransportClient.java
@@ -33,7 +33,8 @@ public class TestSslTransportClient {
         MockVeniceRouterWrapper router =
             ServiceFactory.getMockVeniceRouter(zkServer.getAddress(), true, new Properties())) {
       String routerSslUrl = "https://" + router.getHost() + ":" + router.getSslPort();
-      try (HttpsTransportClient client = new HttpsTransportClient(routerSslUrl, SslUtils.getVeniceLocalSslFactory(), null)) {
+      try (HttpsTransportClient client =
+          new HttpsTransportClient(routerSslUrl, SslUtils.getVeniceLocalSslFactory(), null)) {
 
         TransportClientResponse transportClientResponse = client.get(leaderControllerPath).get();
         byte[] response = transportClientResponse.getBody();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/client/store/TestSslTransportClient.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/client/store/TestSslTransportClient.java
@@ -33,7 +33,7 @@ public class TestSslTransportClient {
         MockVeniceRouterWrapper router =
             ServiceFactory.getMockVeniceRouter(zkServer.getAddress(), true, new Properties())) {
       String routerSslUrl = "https://" + router.getHost() + ":" + router.getSslPort();
-      try (HttpsTransportClient client = new HttpsTransportClient(routerSslUrl, SslUtils.getVeniceLocalSslFactory())) {
+      try (HttpsTransportClient client = new HttpsTransportClient(routerSslUrl, SslUtils.getVeniceLocalSslFactory(), null)) {
 
         TransportClientResponse transportClientResponse = client.get(leaderControllerPath).get();
         byte[] response = transportClientResponse.getBody();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestJWTAuthenticationEndToEnd.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestJWTAuthenticationEndToEnd.java
@@ -1,0 +1,86 @@
+package com.linkedin.venice.controller;
+
+import static com.linkedin.venice.ConfigKeys.ALLOW_CLUSTER_WIPE;
+import static com.linkedin.venice.ConfigKeys.LOCAL_REGION_NAME;
+import static com.linkedin.venice.ConfigKeys.TOPIC_CLEANUP_DELAY_FACTOR;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authentication.jwt.TokenAuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
+import com.linkedin.venice.authorization.SimpleAuthorizerService;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterCreateOptions;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.meta.Store;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Optional;
+import java.util.Properties;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestJWTAuthenticationEndToEnd {
+  private static final int TEST_TIMEOUT = 30 * Time.MS_PER_SECOND;
+
+  String clusterName;
+  VeniceClusterWrapper venice;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    Properties properties = new Properties();
+    properties.setProperty(LOCAL_REGION_NAME, "dc-0");
+    properties.setProperty(ALLOW_CLUSTER_WIPE, "true");
+    properties.setProperty(TOPIC_CLEANUP_DELAY_FACTOR, "0");
+    AuthenticationService authenticationService = new TokenAuthenticationService();
+    Properties authProperties = new Properties();
+    authProperties.setProperty("authentication.service.class", TokenAuthenticationService.class.getName());
+    authProperties.setProperty("authentication.jwt.secretKey", "jDdra78Vo1+RVMGY2easnWe0sAFrEa2581ra5YMotbE=");
+    authenticationService.initialise(new VeniceProperties(authProperties));
+
+    AuthorizerService authorizerService = new SimpleAuthorizerService();
+
+    VeniceClusterCreateOptions options = new VeniceClusterCreateOptions.Builder().numberOfControllers(1)
+        .numberOfServers(0)
+        .numberOfRouters(0)
+        .replicationFactor(1)
+        .partitionSize(1)
+        .minActiveReplica(1)
+        .authenticationService(authenticationService)
+        .authorizerService(authorizerService)
+        .build();
+
+    venice = ServiceFactory.getVeniceCluster(options);
+    clusterName = venice.getClusterName();
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    venice.close();
+  }
+
+  @Test(timeOut = TEST_TIMEOUT)
+  public void testNewStore() throws Exception {
+    String storeName = Utils.getUniqueString("test");
+    String token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.DBjI5MJuVyCa6oncrP5eEP329Pmixk6SX4UG-HS0P7g";
+    String schema = "{\"name\": \"key\",\"type\": \"string\"}";
+    try (ControllerClient controllerClient = ControllerClient
+        .constructClusterControllerClient(clusterName, venice.getAllControllersURLs(), Optional.empty(), null);) {
+      controllerClient.createNewStore(storeName, "dev", schema, schema);
+      Store store = venice.getLeaderVeniceController().getVeniceAdmin().getStore(clusterName, storeName);
+      assertNull(store);
+    }
+
+    try (ControllerClient controllerClient = ControllerClient
+        .constructClusterControllerClient(clusterName, venice.getAllControllersURLs(), Optional.empty(), token);) {
+      controllerClient.createNewStore(storeName, "dev", schema, schema);
+      Store store = venice.getLeaderVeniceController().getVeniceAdmin().getStore(clusterName, storeName);
+      assertNotNull(store);
+    }
+  }
+}

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
@@ -62,6 +62,8 @@ public class TestVeniceServer extends VeniceServer {
         sslFactory,
         routerAccessController,
         storeAccessController,
+          Optional.empty(),
+          Optional.empty(),
         diskHealthService,
         compressorFactory,
         resourceReadUsageTracker) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/TestVeniceServer.java
@@ -62,8 +62,8 @@ public class TestVeniceServer extends VeniceServer {
         sslFactory,
         routerAccessController,
         storeAccessController,
-          Optional.empty(),
-          Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
         diskHealthService,
         compressorFactory,
         resourceReadUsageTracker) {

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterCreateOptions.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterCreateOptions.java
@@ -9,6 +9,8 @@ import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstant
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_KAFKA;
 import static com.linkedin.venice.integration.utils.VeniceClusterWrapperConstants.DEFAULT_SSL_TO_STORAGE_NODES;
 
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.utils.Utils;
 import java.util.Collections;
 import java.util.Map;
@@ -34,6 +36,8 @@ public class VeniceClusterCreateOptions {
   private final boolean sslToKafka;
   private final boolean isKafkaOpenSSLEnabled;
   private final boolean forkServer;
+  private final AuthenticationService authenticationService;
+  private final AuthorizerService authorizerService;
   private final Properties extraProperties;
   private final Map<String, Map<String, String>> kafkaClusterMap;
   private final ZkServerWrapper zkServerWrapper;
@@ -62,6 +66,8 @@ public class VeniceClusterCreateOptions {
     this.kafkaClusterMap = builder.kafkaClusterMap;
     this.zkServerWrapper = builder.zkServerWrapper;
     this.pubSubBrokerWrapper = builder.pubSubBrokerWrapper;
+    this.authenticationService = builder.authenticationService;
+    this.authorizerService = builder.authorizerService;
   }
 
   public String getClusterName() {
@@ -150,6 +156,14 @@ public class VeniceClusterCreateOptions {
 
   public PubSubBrokerWrapper getKafkaBrokerWrapper() {
     return pubSubBrokerWrapper;
+  }
+
+  public AuthenticationService getAuthenticationService() {
+    return authenticationService;
+  }
+
+  public AuthorizerService getAuthorizerService() {
+    return authorizerService;
   }
 
   @Override
@@ -247,6 +261,8 @@ public class VeniceClusterCreateOptions {
     private Map<String, Map<String, String>> kafkaClusterMap;
     private ZkServerWrapper zkServerWrapper;
     private PubSubBrokerWrapper pubSubBrokerWrapper;
+    private AuthenticationService authenticationService;
+    private AuthorizerService authorizerService;
 
     public Builder clusterName(String clusterName) {
       this.clusterName = clusterName;
@@ -341,6 +357,16 @@ public class VeniceClusterCreateOptions {
 
     public Builder extraProperties(Properties extraProperties) {
       this.extraProperties = extraProperties;
+      return this;
+    }
+
+    public Builder authenticationService(AuthenticationService authenticationService) {
+      this.authenticationService = authenticationService;
+      return this;
+    }
+
+    public Builder authorizerService(AuthorizerService authorizerService) {
+      this.authorizerService = authorizerService;
       return this;
     }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceClusterWrapper.java
@@ -228,6 +228,8 @@ public class VeniceClusterWrapper extends ProcessWrapper {
                 .clusterToD2(clusterToD2)
                 .clusterToServerD2(clusterToServerD2)
                 .sslToKafka(options.isSslToKafka())
+                .authenticationService(options.getAuthenticationService())
+                .authorizerService(options.getAuthorizerService())
                 .d2Enabled(true)
                 .regionName(options.getRegionName())
                 .extraProperties(options.getExtraProperties())

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -211,9 +211,13 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
 
     d2Servers.addAll(D2TestUtils.getD2Servers(zkAddress, clusterDiscoveryD2ClusterName, httpURI, httpsURI));
 
-    service =
-        new RouterServer(properties, d2Servers, Optional.empty(), Optional.empty(),Optional.empty(),
-                Optional.of(SslUtils.getVeniceLocalSslFactory()));
+    service = new RouterServer(
+        properties,
+        d2Servers,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(SslUtils.getVeniceLocalSslFactory()));
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -154,6 +154,8 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           routerProperties,
           d2Servers,
           Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
           Optional.of(SslUtils.getVeniceLocalSslFactory()));
       return new VeniceRouterWrapper(
           regionName,
@@ -210,7 +212,8 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
     d2Servers.addAll(D2TestUtils.getD2Servers(zkAddress, clusterDiscoveryD2ClusterName, httpURI, httpsURI));
 
     service =
-        new RouterServer(properties, d2Servers, Optional.empty(), Optional.of(SslUtils.getVeniceLocalSslFactory()));
+        new RouterServer(properties, d2Servers, Optional.empty(), Optional.empty(),Optional.empty(),
+                Optional.of(SslUtils.getVeniceLocalSslFactory()));
   }
 
   @Override

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/integration/utils/VeniceRouterWrapper.java
@@ -21,6 +21,8 @@ import static com.linkedin.venice.ConfigKeys.SYSTEM_SCHEMA_CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.ZOOKEEPER_ADDRESS;
 import static com.linkedin.venice.VeniceConstants.DEFAULT_PER_ROUTER_READ_QUOTA;
 
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.client.store.ClientConfig;
 import com.linkedin.venice.helix.HelixBaseRoutingRepository;
 import com.linkedin.venice.helix.ZkRoutersClusterManager;
@@ -154,8 +156,8 @@ public class VeniceRouterWrapper extends ProcessWrapper implements MetricsAware 
           routerProperties,
           d2Servers,
           Optional.empty(),
-          Optional.empty(),
-          Optional.empty(),
+          Optional.ofNullable((AuthenticationService) properties.get("AuthenticationService")),
+          Optional.ofNullable((AuthorizerService) properties.get("AuthorizerService")),
           Optional.of(SslUtils.getVeniceLocalSslFactory()));
       return new VeniceRouterWrapper(
           regionName,

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterWithTokenAuthentication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterWithTokenAuthentication.java
@@ -1,0 +1,105 @@
+package com.linkedin.venice.router;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authentication.jwt.TokenAuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
+import com.linkedin.venice.authorization.SimpleAuthorizerService;
+import com.linkedin.venice.client.exceptions.VeniceClientHttpException;
+import com.linkedin.venice.client.store.AvroGenericStoreClient;
+import com.linkedin.venice.client.store.ClientConfig;
+import com.linkedin.venice.client.store.ClientFactory;
+import com.linkedin.venice.controllerapi.ControllerClient;
+import com.linkedin.venice.integration.utils.ServiceFactory;
+import com.linkedin.venice.integration.utils.VeniceClusterWrapper;
+import com.linkedin.venice.integration.utils.VeniceRouterWrapper;
+import com.linkedin.venice.utils.Time;
+import com.linkedin.venice.utils.Utils;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class TestRouterWithTokenAuthentication {
+  private static final String KEY_SCHEMA_STR = "\"string\"";
+
+  private static final String VALUE_SCHEMA_STR =
+      "{\n" + "\"type\": \"record\",\n" + "\"name\": \"test_value_schema\",\n" + "\"fields\": [\n" + "  {\"name\": \""
+          + "int_field\", \"type\": \"int\"}]\n" + "}";
+  private VeniceClusterWrapper veniceCluster;
+  private String storeName;
+
+  @BeforeClass(alwaysRun = true)
+  public void setUp() throws Exception {
+    Utils.thisIsLocalhost();
+    veniceCluster = ServiceFactory.getVeniceCluster(1, 1, 0, 1, 100, false, false);
+
+    Properties tokenProperties = new Properties();
+    tokenProperties.put("authentication.jwt.secretKey", "jDdra78Vo1+RVMGY2easnWe0sAFrEa2581ra5YMotbE=");
+
+    // we need to create the instances there due to some classpath problems
+    AuthenticationService tokenAuthenticationService = new TokenAuthenticationService();
+    tokenAuthenticationService.initialise(new VeniceProperties(tokenProperties));
+    AuthorizerService simpleAuthorizerService = new SimpleAuthorizerService();
+
+    Properties routerProperties = new Properties();
+    routerProperties.put("AuthenticationService", tokenAuthenticationService);
+    routerProperties.put("AuthorizerService", simpleAuthorizerService);
+    veniceCluster.addVeniceRouter(routerProperties);
+
+    // Create test store
+    storeName = Utils.getUniqueString("store");
+
+    try (ControllerClient controllerClient =
+        new ControllerClient(veniceCluster.getClusterName(), veniceCluster.getAllControllersURLs());) {
+      assertFalse(controllerClient.createNewStore(storeName, "dev", KEY_SCHEMA_STR, VALUE_SCHEMA_STR).isError());
+      assertFalse(controllerClient.emptyPush(storeName, "xxx", 1).isError());
+    }
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void cleanUp() {
+    Utils.closeQuietlyWithErrorLogged(veniceCluster);
+  }
+
+  @Test(timeOut = 60 * Time.MS_PER_SECOND)
+  public void smokeTest() throws Exception {
+    List<VeniceRouterWrapper> routers = veniceCluster.getVeniceRouters();
+    assertEquals(1, routers.size(), "There should be only one router in this cluster");
+
+    // No token
+    try (AvroGenericStoreClient<Object, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName).setVeniceURL("http://" + routers.get(0).getAddress()))) {
+      storeClient.get("myKey").get();
+    } catch (ExecutionException ok) {
+      VeniceClientHttpException veniceClientHttpException = (VeniceClientHttpException) ok.getCause();
+      assertEquals(401, veniceClientHttpException.getHttpStatus());
+    }
+
+    // bad token
+    try (AvroGenericStoreClient<Object, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL("http://" + routers.get(0).getAddress())
+            .setToken("xxx"))) {
+      storeClient.get("myKey").get();
+    } catch (ExecutionException ok) {
+      VeniceClientHttpException veniceClientHttpException = (VeniceClientHttpException) ok.getCause();
+      assertEquals(401, veniceClientHttpException.getHttpStatus());
+    }
+
+    // good token
+    try (AvroGenericStoreClient<Object, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(
+        ClientConfig.defaultGenericClientConfig(storeName)
+            .setVeniceURL("http://" + routers.get(0).getAddress())
+            .setToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.DBjI5MJuVyCa6oncrP5eEP329Pmixk6SX4UG-HS0P7g"))) {
+      assertNull(storeClient.get("myKey").get());
+    }
+  }
+}

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/RouterServer.java
@@ -12,6 +12,10 @@ import com.linkedin.alpini.router.impl.Router;
 import com.linkedin.venice.ConfigKeys;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.handler.StoreAclHandler;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authentication.AuthenticationServiceUtils;
+import com.linkedin.venice.authorization.AuthorizerService;
+import com.linkedin.venice.authorization.AuthorizerServiceUtils;
 import com.linkedin.venice.compression.CompressorFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.helix.HelixAdapterSerializer;
@@ -119,6 +123,8 @@ public class RouterServer extends AbstractVeniceService {
   private final MetricsRepository metricsRepository;
   private final Optional<SSLFactory> sslFactory;
   private final Optional<DynamicAccessController> accessController;
+  private final Optional<AuthenticationService> authenticationService;
+  private final Optional<AuthorizerService> authorizerService;
 
   private final VeniceRouterConfig config;
 
@@ -202,7 +208,16 @@ public class RouterServer extends AbstractVeniceService {
     LOGGER.info("IO worker count: {}", props.getInt(ConfigKeys.ROUTER_IO_WORKER_COUNT));
 
     Optional<SSLFactory> sslFactory = Optional.of(SslUtils.getVeniceLocalSslFactory());
-    RouterServer server = new RouterServer(props, new ArrayList<>(), Optional.empty(), sslFactory);
+    Optional<AuthenticationService> authenticationService =
+        AuthenticationServiceUtils.buildAuthenticationService(props);
+    Optional<AuthorizerService> authorizerService = AuthorizerServiceUtils.buildAuthorizerService(props);
+    RouterServer server = new RouterServer(
+        props,
+        new ArrayList<>(),
+        Optional.empty(),
+        authenticationService,
+        authorizerService,
+        sslFactory);
     server.start();
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -229,11 +244,15 @@ public class RouterServer extends AbstractVeniceService {
       VeniceProperties properties,
       List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers,
       Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
       Optional<SSLFactory> sslFactory) {
     this(
         properties,
         serviceDiscoveryAnnouncers,
         accessController,
+        authenticationService,
+        authorizerService,
         sslFactory,
         TehutiUtils.getMetricsRepository(ROUTER_SERVICE_NAME));
   }
@@ -247,9 +266,19 @@ public class RouterServer extends AbstractVeniceService {
       VeniceProperties properties,
       List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers,
       Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
       Optional<SSLFactory> sslFactory,
       MetricsRepository metricsRepository) {
-    this(properties, serviceDiscoveryAnnouncers, accessController, sslFactory, metricsRepository, true);
+    this(
+        properties,
+        serviceDiscoveryAnnouncers,
+        accessController,
+        authenticationService,
+        authorizerService,
+        sslFactory,
+        metricsRepository,
+        true);
 
     HelixReadOnlyZKSharedSystemStoreRepository readOnlyZKSharedSystemStoreRepository =
         new HelixReadOnlyZKSharedSystemStoreRepository(zkClient, adapter, config.getSystemSchemaClusterName());
@@ -307,6 +336,8 @@ public class RouterServer extends AbstractVeniceService {
       VeniceProperties properties,
       List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers,
       Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
       Optional<SSLFactory> sslFactory,
       MetricsRepository metricsRepository,
       boolean isCreateHelixManager) {
@@ -327,6 +358,8 @@ public class RouterServer extends AbstractVeniceService {
 
     this.serviceDiscoveryAnnouncers = serviceDiscoveryAnnouncers;
     this.accessController = accessController;
+    this.authenticationService = authenticationService;
+    this.authorizerService = authorizerService;
     this.sslFactory = sslFactory;
     verifySslOk();
   }
@@ -347,7 +380,15 @@ public class RouterServer extends AbstractVeniceService {
       List<ServiceDiscoveryAnnouncer> serviceDiscoveryAnnouncers,
       Optional<SSLFactory> sslFactory,
       HelixLiveInstanceMonitor liveInstanceMonitor) {
-    this(properties, serviceDiscoveryAnnouncers, Optional.empty(), sslFactory, new MetricsRepository(), false);
+    this(
+        properties,
+        serviceDiscoveryAnnouncers,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        sslFactory,
+        new MetricsRepository(),
+        false);
     this.routingDataRepository = routingDataRepository;
     this.hybridStoreQuotaRepository = hybridStoreQuotaRepository;
     this.metadataRepository = metadataRepository;
@@ -570,7 +611,14 @@ public class RouterServer extends AbstractVeniceService {
     AdminOperationsStats adminOperationsStats = new AdminOperationsStats(this.metricsRepository, "admin_stats", config);
     AdminOperationsHandler adminOperationsHandler =
         new AdminOperationsHandler(accessController.orElse(null), this, adminOperationsStats);
-
+    StoreAclHandler aclHandler = accessController.isPresent() || authenticationService.isPresent()
+        ? new StoreAclHandler(accessController, authenticationService, authorizerService, metadataRepository)
+        : null;
+    LOGGER.info(
+        "StoreAclHandler {} AuthenticationService {} AuthorizerService {}",
+        aclHandler,
+        authenticationService,
+        authorizerService);
     // TODO: deprecate non-ssl port
     if (!config.isEnforcingSecureOnly()) {
       router = Optional.of(
@@ -590,6 +638,9 @@ public class RouterServer extends AbstractVeniceService {
                 pipeline.addLast("VerifySslHandler", unsecureRouterSslVerificationHandler);
                 pipeline.addLast("MetadataHandler", metaDataHandler);
                 pipeline.addLast("AdminOperationsHandler", adminOperationsHandler);
+                if (authenticationService.isPresent()) {
+                  pipeline.addLast("StoreAclHandler", aclHandler);
+                }
                 addStreamingHandler(pipeline);
                 addOptionalChannelHandlersToPipeline(pipeline);
               })
@@ -599,8 +650,7 @@ public class RouterServer extends AbstractVeniceService {
     }
 
     RouterSslVerificationHandler routerSslVerificationHandler = new RouterSslVerificationHandler(securityStats);
-    StoreAclHandler aclHandler =
-        accessController.isPresent() ? new StoreAclHandler(accessController.get(), metadataRepository) : null;
+
     final SslInitializer sslInitializer;
     if (sslFactory.isPresent()) {
       sslInitializer = new SslInitializer(SslUtils.toAlpiniSSLFactory(sslFactory.get()), false);
@@ -669,15 +719,17 @@ public class RouterServer extends AbstractVeniceService {
                                                                                                          // compared
                                                                                                          // once per
                                                                                                          // request.
-        .beforeHttpRequestHandler(ChannelPipeline.class, accessController.isPresent() ? withAcl : withoutAcl) // Compare
-                                                                                                              // once
-                                                                                                              // per
-                                                                                                              // router.
-                                                                                                              // Previously
-                                                                                                              // compared
-                                                                                                              // once
-                                                                                                              // per
-                                                                                                              // request.
+        .beforeHttpRequestHandler(
+            ChannelPipeline.class,
+            accessController.isPresent() || authenticationService.isPresent() ? withAcl : withoutAcl) // Compare
+                                                                                                      // once
+                                                                                                      // per
+                                                                                                      // router.
+                                                                                                      // Previously
+                                                                                                      // compared
+                                                                                                      // once
+                                                                                                      // per
+                                                                                                      // request.
         .idleTimeout(3, TimeUnit.HOURS)
         .enableInboundHttp2(config.isHttp2InboundEnabled())
         .http2MaxConcurrentStreams(config.getHttp2MaxConcurrentStreams())
@@ -799,6 +851,12 @@ public class RouterServer extends AbstractVeniceService {
     }
     if (heartbeat != null) {
       heartbeat.stopInner();
+    }
+    if (authenticationService.isPresent()) {
+      Utils.closeQuietlyWithErrorLogged(authenticationService.get());
+    }
+    if (authenticationService.isPresent()) {
+      Utils.closeQuietlyWithErrorLogged(authenticationService.get());
     }
   }
 

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ListenerService.java
@@ -8,6 +8,8 @@ import com.linkedin.davinci.storage.MetadataRetriever;
 import com.linkedin.davinci.storage.StorageEngineRepository;
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.StaticAccessController;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.cleaner.ResourceReadUsageTracker;
 import com.linkedin.venice.helix.HelixCustomizedViewOfflinePushRepository;
 import com.linkedin.venice.meta.ReadOnlySchemaRepository;
@@ -64,6 +66,8 @@ public class ListenerService extends AbstractVeniceService {
       Optional<SSLFactory> sslFactory,
       Optional<StaticAccessController> routerAccessController,
       Optional<DynamicAccessController> storeAccessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
       DiskHealthCheckService diskHealthService,
       StorageEngineBackedCompressorFactory compressorFactory,
       Optional<ResourceReadUsageTracker> resourceReadUsageTracker) {
@@ -114,6 +118,8 @@ public class ListenerService extends AbstractVeniceService {
         serverConfig,
         routerAccessController,
         storeAccessController,
+        authenticationService,
+        authorizerService,
         requestHandler);
 
     Class<? extends ServerChannel> serverSocketChannelClass = NioServerSocketChannel.class;

--- a/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStoreAclHandler.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/listener/ServerStoreAclHandler.java
@@ -2,6 +2,8 @@ package com.linkedin.venice.listener;
 
 import com.linkedin.venice.acl.DynamicAccessController;
 import com.linkedin.venice.acl.handler.StoreAclHandler;
+import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.ReadOnlyStoreRepository;
 import com.linkedin.venice.meta.Version;
@@ -25,8 +27,12 @@ import javax.net.ssl.SSLPeerUnverifiedException;
  * If both of them fail, the request will be rejected.
  */
 public class ServerStoreAclHandler extends StoreAclHandler {
-  public ServerStoreAclHandler(DynamicAccessController accessController, ReadOnlyStoreRepository metadataRepository) {
-    super(accessController, metadataRepository);
+  public ServerStoreAclHandler(
+      Optional<DynamicAccessController> accessController,
+      Optional<AuthenticationService> authenticationService,
+      Optional<AuthorizerService> authorizerService,
+      ReadOnlyStoreRepository metadataRepository) {
+    super(accessController, authenticationService, authorizerService, metadataRepository);
   }
 
   /**

--- a/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
+++ b/services/venice-server/src/main/java/com/linkedin/venice/server/VeniceServer.java
@@ -675,6 +675,8 @@ public class VeniceServer {
         sslFactory,
         routerAccessController,
         storeAccessController,
+        Optional.empty(),
+        Optional.empty(),
         diskHealthService,
         compressorFactory,
         resourceReadUsageTracker);

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/HttpChannelInitializerTest.java
@@ -62,6 +62,8 @@ public class HttpChannelInitializerTest {
         serverConfig,
         accessController,
         storeAccessController,
+        Optional.empty(),
+        Optional.empty(),
         requestHandler);
     Assert.assertNotNull(initializer.getQuotaEnforcer());
   }
@@ -79,6 +81,8 @@ public class HttpChannelInitializerTest {
         serverConfig,
         accessController,
         storeAccessController,
+        Optional.empty(),
+        Optional.empty(),
         requestHandler);
     Assert.assertNull(initializer.getQuotaEnforcer());
   }
@@ -100,6 +104,8 @@ public class HttpChannelInitializerTest {
         serverConfig,
         accessController,
         storeAccessController,
+        Optional.empty(),
+        Optional.empty(),
         requestHandler);
     initializer.initChannel(ch);
   }

--- a/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
+++ b/services/venice-server/src/test/java/com/linkedin/venice/listener/ListenerServiceTest.java
@@ -80,6 +80,8 @@ public class ListenerServiceTest {
         sslFactory,
         routerAccessController,
         storeAccessController,
+        Optional.empty(),
+        Optional.empty(),
         diskHealthService,
         compressorFactory,
         resourceReadUsageTracker);


### PR DESCRIPTION
Key points:
- Bootstrap AuthenticationService and AuthorizerService in the Router Service
- Ensure that those components are called in Router APIs (even if https is disabled and even the legacy access controller is disabled)
- Implement "Token" authentication in the FastClient and in the regular Java Client (DaVinci may be already covered, but it would need ad-hoc testing)
- Add the "token" configuration in the CLI query tool, the Venice Java Client and in the Pulsar Venice Sink

Performance notes:
- Authentication is performed only once per TCP connection
- This can be achieved only if all the requests coming from the connection contain the same "Authorization" header
- This works well because the Venice Client re-uses the same connection and the token is configured at client level
- This caching works only for HTTP Authentication based on the "Authorization" header, and it is enough for the current usecase

Note:
- we are touching the VeniceServer code, that share some parts in common with the Router, but Authn/Authz won't be enabled yet
- Unfortunately we are adding the "token" parameter everywhere, this is kind of a code smell, we are following the same path as SSLFactory (that is the TLS client cert authentication basically)
