### PR TITLE
[controller] Ensure that AuthenticationService is always executed

### DIFF
--- a/internal/venice-test-common/src/main/java/com/linkedin/venice/controller/MockVeniceAuthorizer.java
+++ b/internal/venice-test-common/src/main/java/com/linkedin/venice/controller/MockVeniceAuthorizer.java
@@ -48,4 +48,9 @@ public class MockVeniceAuthorizer implements AuthorizerService {
 
   public void removeAce(Resource resource, AceEntry aceEntry) {
   }
+
+  @Override
+  public boolean isSuperUser(Principal principal, String storeName) {
+    return true;
+  }
 }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/AuditInfo.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/AuditInfo.java
@@ -1,5 +1,7 @@
 package com.linkedin.venice.controller;
 
+import static com.linkedin.venice.controller.server.AdminSparkServer.REQUEST_PRINCIPAL_ATTRIBUTE_NAME;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
@@ -10,6 +12,7 @@ public class AuditInfo {
   private String url;
   private Map<String, String> params;
   private String method;
+  private Object principal;
 
   public AuditInfo(Request request) {
     this.url = request.url();
@@ -18,6 +21,7 @@ public class AuditInfo {
       this.params.put(param, request.queryParams(param));
     }
     this.method = request.requestMethod();
+    this.principal = request.attribute(REQUEST_PRINCIPAL_ATTRIBUTE_NAME);
   }
 
   /**
@@ -27,6 +31,9 @@ public class AuditInfo {
   public String toString() {
     StringJoiner joiner = new StringJoiner(" ");
     joiner.add("[AUDIT]");
+    if (principal != null) {
+      joiner.add(principal.toString());
+    }
     joiner.add(method);
     joiner.add(url);
     joiner.add(params.toString());
@@ -50,6 +57,9 @@ public class AuditInfo {
   private String toString(boolean success, String errMsg) {
     StringJoiner joiner = new StringJoiner(" ");
     joiner.add("[AUDIT]");
+    if (principal != null) {
+      joiner.add(principal.toString());
+    }
     if (success) {
       joiner.add("SUCCESS");
     } else {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminCommandExecutionRoutes.java
@@ -8,7 +8,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.LAST_SUCCEED_EXE
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.LastSucceedExecutionIdResponse;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
@@ -22,9 +21,8 @@ public class AdminCommandExecutionRoutes extends AbstractRoute {
   public AdminCommandExecutionRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/AdminTopicMetadataRoutes.java
@@ -10,7 +10,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ADMIN_TOP
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminTopicMetadataAccessor;
@@ -29,9 +28,8 @@ public class AdminTopicMetadataRoutes extends AbstractRoute {
   public AdminTopicMetadataRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ClusterRoutes.java
@@ -10,7 +10,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_CLUSTER_C
 import static com.linkedin.venice.controllerapi.ControllerRoute.WIPE_CLUSTER;
 
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -28,9 +27,8 @@ public class ClusterRoutes extends AbstractRoute {
   public ClusterRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/ControllerRoutes.java
@@ -13,7 +13,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_KAFKA_TOP
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ChildAwareResponse;
@@ -40,9 +39,8 @@ public class ControllerRoutes extends AbstractRoute {
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
       PubSubTopicRepository pubSubTopicRepository,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
     this.pubSubTopicRepository = pubSubTopicRepository;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateStore.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateStore.java
@@ -14,7 +14,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_ACL;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.AclResponse;
@@ -29,9 +28,8 @@ public class CreateStore extends AbstractRoute {
   public CreateStore(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/CreateVersion.java
@@ -27,7 +27,6 @@ import static com.linkedin.venice.meta.Version.REPLICATION_METADATA_VERSION_ID_U
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.controller.Admin;
@@ -66,9 +65,8 @@ public class CreateVersion extends AbstractRoute {
       Optional<DynamicAccessController> accessController,
       boolean checkReadMethodForKafka,
       boolean disableParentRequestTopicForStreamPushes,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
     this.checkReadMethodForKafka = checkReadMethodForKafka;
     this.disableParentRequestTopicForStreamPushes = disableParentRequestTopicForStreamPushes;
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/DataRecoveryRoutes.java
@@ -13,7 +13,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.IS_STORE_VERSION
 import static com.linkedin.venice.controllerapi.ControllerRoute.PREPARE_DATA_RECOVERY;
 
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -36,9 +35,8 @@ public class DataRecoveryRoutes extends AbstractRoute {
   public DataRecoveryRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/HttpRequestAccessor.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/HttpRequestAccessor.java
@@ -1,0 +1,39 @@
+package com.linkedin.venice.controller.server;
+
+import static com.linkedin.venice.VeniceConstants.CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME;
+
+import com.linkedin.venice.authentication.AuthenticationService;
+import java.security.cert.X509Certificate;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import spark.Request;
+
+
+public class HttpRequestAccessor implements AuthenticationService.HttpRequestAccessor {
+  private final Request request;
+
+  public HttpRequestAccessor(Request request) {
+    this.request = request;
+  }
+
+  @Override
+  public String getHeader(String headerName) {
+    return request.headers(headerName);
+  }
+
+  @Override
+  public X509Certificate getCertificate() {
+    HttpServletRequest rawRequest = request.raw();
+    Object certificateObject = rawRequest.getAttribute(CONTROLLER_SSL_CERTIFICATE_ATTRIBUTE_NAME);
+    if (certificateObject == null) {
+      return null;
+    }
+    return ((X509Certificate[]) certificateObject)[0];
+  }
+
+  @Override
+  public String toString() {
+    return "Request {" + request.requestMethod() + ", " + request.pathInfo() + "?" + request.queryString()
+        + request.headers().stream().map(h -> h + ":" + request.headers(h)).collect(Collectors.joining()) + "}";
+  }
+}

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/JobRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/JobRoutes.java
@@ -15,7 +15,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SEND_PUSH_JOB_DE
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -47,9 +46,8 @@ public class JobRoutes extends AbstractRoute {
   public JobRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/MigrationRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/MigrationRoutes.java
@@ -6,7 +6,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SET_MIGRATION_PU
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -21,9 +20,8 @@ public class MigrationRoutes extends AbstractRoute {
   public MigrationRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NewClusterBuildOutRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NewClusterBuildOutRoutes.java
@@ -7,7 +7,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.SOURCE_FA
 import static com.linkedin.venice.controllerapi.ControllerRoute.REPLICATE_META_DATA;
 
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.StoreResponse;
@@ -21,9 +20,8 @@ public class NewClusterBuildOutRoutes extends AbstractRoute {
   public NewClusterBuildOutRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/NodesAndReplicas.java
@@ -20,7 +20,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_NODE;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.NodeRemovableResult;
@@ -60,9 +59,8 @@ public class NodesAndReplicas extends AbstractRoute {
   public NodesAndReplicas(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/RoutersClusterConfigRoutes.java
@@ -9,7 +9,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.ENABLE_THROTTLIN
 import static com.linkedin.venice.controllerapi.ControllerRoute.GET_ROUTERS_CLUSTER_CONFIG;
 
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -24,9 +23,8 @@ public class RoutersClusterConfigRoutes extends AbstractRoute {
   public RoutersClusterConfigRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SchemaRoutes.java
@@ -18,7 +18,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.REMOVE_DERIVED_S
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerApiConstants;
@@ -49,9 +48,8 @@ public class SchemaRoutes extends AbstractRoute {
   public SchemaRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/SkipAdminRoute.java
@@ -7,7 +7,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.SKIP_ADMIN;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -22,9 +21,8 @@ public class SkipAdminRoute extends AbstractRoute {
   public SkipAdminRoute(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoragePersonaRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoragePersonaRoutes.java
@@ -11,7 +11,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.GET_STORAGE_PERS
 import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORAGE_PERSONA;
 
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.ControllerResponse;
@@ -32,9 +31,8 @@ public class StoragePersonaRoutes extends AbstractRoute {
   public StoragePersonaRoutes(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/StoresRoutes.java
@@ -53,7 +53,6 @@ import static com.linkedin.venice.controllerapi.ControllerRoute.UPDATE_STORE;
 
 import com.linkedin.venice.HttpConstants;
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controller.AdminCommandExecutionTracker;
@@ -115,9 +114,8 @@ public class StoresRoutes extends AbstractRoute {
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
       PubSubTopicRepository pubSubTopicRepository,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
     this.pubSubTopicRepository = pubSubTopicRepository;
   }
 

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VersionRoute.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/server/VersionRoute.java
@@ -4,7 +4,6 @@ import static com.linkedin.venice.controllerapi.ControllerApiConstants.CLUSTER;
 import static com.linkedin.venice.controllerapi.ControllerRoute.LIST_BOOTSTRAPPING_VERSIONS;
 
 import com.linkedin.venice.acl.DynamicAccessController;
-import com.linkedin.venice.authentication.AuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.controller.Admin;
 import com.linkedin.venice.controllerapi.MultiVersionStatusResponse;
@@ -17,9 +16,8 @@ public class VersionRoute extends AbstractRoute {
   public VersionRoute(
       boolean sslEnabled,
       Optional<DynamicAccessController> accessController,
-      Optional<AuthenticationService> authenticationService,
       Optional<AuthorizerService> authorizerService) {
-    super(sslEnabled, accessController, authenticationService, authorizerService);
+    super(sslEnabled, accessController, authorizerService);
   }
 
   /**

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/ControllerRoutesTest.java
@@ -39,9 +39,8 @@ public class ControllerRoutesTest {
     Request request = mock(Request.class);
     doReturn(TEST_CLUSTER).when(request).queryParams(eq(ControllerApiConstants.CLUSTER));
 
-    Route leaderControllerRoute =
-        new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, Optional.empty(), Optional.empty())
-            .getLeaderController(mockAdmin);
+    Route leaderControllerRoute = new ControllerRoutes(false, Optional.empty(), pubSubTopicRepository, Optional.empty())
+        .getLeaderController(mockAdmin);
     LeaderControllerResponse leaderControllerResponse = ObjectMapperFactory.getInstance()
         .readValue(
             leaderControllerRoute.handle(request, mock(Response.class)).toString(),
@@ -51,7 +50,7 @@ public class ControllerRoutesTest {
     Assert.assertEquals(leaderControllerResponse.getSecureUrl(), "https://" + TEST_HOST + ":" + TEST_SSL_PORT);
 
     Route leaderControllerSslRoute =
-        new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository, Optional.empty(), Optional.empty())
+        new ControllerRoutes(true, Optional.empty(), pubSubTopicRepository, Optional.empty())
             .getLeaderController(mockAdmin);
     LeaderControllerResponse leaderControllerResponseSsl = ObjectMapperFactory.getInstance()
         .readValue(

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateStoreTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateStoreTest.java
@@ -53,7 +53,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
@@ -82,7 +82,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
   }
@@ -102,7 +102,7 @@ public class CreateStoreTest {
 
     doReturn(clusterName).when(request).queryParams(CLUSTER);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpStatus.SC_BAD_REQUEST);
@@ -127,7 +127,7 @@ public class CreateStoreTest {
     doReturn("\"long\"").when(request).queryParams(KEY_SCHEMA);
     doReturn("\"string\"").when(request).queryParams(VALUE_SCHEMA);
 
-    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty(), Optional.empty());
+    CreateStore createStoreRoute = new CreateStore(false, Optional.empty(), Optional.empty());
     Route createStoreRouter = createStoreRoute.createStore(admin);
     createStoreRouter.handle(request, response);
     verify(response).status(HttpConstants.SC_MISDIRECTED_REQUEST);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/CreateVersionTest.java
@@ -109,7 +109,7 @@ public class CreateVersionTest {
      * Build a CreateVersion route.
      */
     CreateVersion createVersion =
-        new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false, Optional.empty(), Optional.empty());
+        new CreateVersion(true, Optional.of(accessClient), checkReadMethod, false, Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     // Not an allowlist user.
@@ -170,8 +170,7 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion =
-        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -223,8 +222,7 @@ public class CreateVersionTest {
     assertTrue(store.isIncrementalPushEnabled());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion =
-        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
 
     Object result = createVersionRoute.handle(request, response);
@@ -276,8 +274,7 @@ public class CreateVersionTest {
     assertTrue(admin.isParent());
 
     // Build a CreateVersion route.
-    CreateVersion createVersion =
-        new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty(), Optional.empty());
+    CreateVersion createVersion = new CreateVersion(true, Optional.of(accessClient), false, false, Optional.empty());
     Route createVersionRoute = createVersion.requestTopicForPushing(admin);
     Object result = createVersionRoute.handle(request, response);
     assertNotNull(result);

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/JobRoutesTest.java
@@ -33,7 +33,7 @@ public class JobRoutesTest {
     String cluster = Utils.getUniqueString("cluster");
     String store = Utils.getUniqueString("store");
     int version = 5;
-    JobRoutes jobRoutes = new JobRoutes(false, Optional.empty(), Optional.empty(), Optional.empty());
+    JobRoutes jobRoutes = new JobRoutes(false, Optional.empty(), Optional.empty());
     JobStatusQueryResponse response =
         jobRoutes.populateJobStatus(cluster, store, version, mockAdmin, Optional.empty(), null);
 

--- a/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
+++ b/services/venice-controller/src/test/java/com/linkedin/venice/controller/server/SchemaRoutesTest.java
@@ -24,7 +24,7 @@ public class SchemaRoutesTest {
     Admin admin = mock(Admin.class);
     when(admin.getValueSchemaId(cluster, store, schemaStr)).thenReturn(SchemaData.INVALID_VALUE_SCHEMA_ID);
     when(admin.getStore(cluster, store)).thenReturn(null);
-    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty(), Optional.empty(), Optional.empty());
+    SchemaRoutes schemaRoutes = new SchemaRoutes(false, Optional.empty(), Optional.empty());
     try {
       schemaRoutes.populateSchemaResponseForValueOrDerivedSchemaID(admin, cluster, store, schemaStr);
     } catch (VeniceNoStoreException e) {


### PR DESCRIPTION
Simplify how we activate the AuthenticationService on the Controller Server.

Summary:
- use a Filter to always execute the AuthenticationService and map the Request with a Principal
- remove the reference to AuthenticationService from all the subclasses of AbstractRoute
- print the Principal in the AUDIT log