### PR TITLE
[authentication] Introduce ClientAuthenticationProvider

### DIFF
--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/ClientConfig.java
@@ -3,6 +3,7 @@ package com.linkedin.venice.fastclient;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.davinci.client.DaVinciClient;
 import com.linkedin.r2.transport.common.Client;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import com.linkedin.venice.client.store.AvroSpecificStoreClient;
@@ -68,7 +69,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
   private final D2Client d2Client;
   private final String clusterDiscoveryD2Service;
 
-  private final String token;
+  private final ClientAuthenticationProvider authenticationProvider;
 
   private ClientConfig(
       String storeName,
@@ -99,14 +100,14 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
       StoreMetadataFetchMode storeMetadataFetchMode,
       D2Client d2Client,
       String clusterDiscoveryD2Service,
-      String token) {
+      ClientAuthenticationProvider authenticationProvider) {
     if (storeName == null || storeName.isEmpty()) {
       throw new VeniceClientException("storeName param shouldn't be empty");
     }
     if (r2Client == null) {
       throw new VeniceClientException("r2Client param shouldn't be null");
     }
-    this.token = token;
+    this.authenticationProvider = authenticationProvider;
     this.r2Client = r2Client;
     this.storeName = storeName;
     this.statsPrefix = (statsPrefix == null ? "" : statsPrefix);
@@ -325,8 +326,8 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     return this.clusterDiscoveryD2Service;
   }
 
-  public String getToken() {
-    return token;
+  public ClientAuthenticationProvider getAuthenticationProvider() {
+    return authenticationProvider;
   }
 
   public static class ClientConfigBuilder<K, V, T extends SpecificRecord> {
@@ -375,10 +376,10 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
     private StoreMetadataFetchMode storeMetadataFetchMode = StoreMetadataFetchMode.DA_VINCI_CLIENT_BASED_METADATA;
     private D2Client d2Client;
     private String clusterDiscoveryD2Service;
-    private String token;
+    private ClientAuthenticationProvider authenticationProvider;
 
-    public ClientConfigBuilder<K, V, T> setToken(String token) {
-      this.token = token;
+    public ClientConfigBuilder<K, V, T> setAuthenticationProvider(ClientAuthenticationProvider authenticationProvider) {
+      this.authenticationProvider = authenticationProvider;
       return this;
     }
 
@@ -535,7 +536,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
 
     public ClientConfigBuilder<K, V, T> clone() {
       return new ClientConfigBuilder().setStoreName(storeName)
-          .setToken(token)
+          .setAuthenticationProvider(authenticationProvider)
           .setR2Client(r2Client)
           .setMetricsRepository(metricsRepository)
           .setStatsPrefix(statsPrefix)
@@ -595,7 +596,7 @@ public class ClientConfig<K, V, T extends SpecificRecord> {
           storeMetadataFetchMode,
           d2Client,
           clusterDiscoveryD2Service,
-          token);
+          authenticationProvider);
     }
   }
 }

--- a/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java
+++ b/clients/venice-client/src/main/java/com/linkedin/venice/fastclient/factory/ClientFactory.java
@@ -58,7 +58,10 @@ public class ClientFactory {
         Objects.requireNonNull(clientConfig.getD2Client());
         return new RequestBasedMetadata(
             clientConfig,
-            new D2TransportClient(clientConfig.getClusterDiscoveryD2Service(), clientConfig.getD2Client()));
+            new D2TransportClient(
+                clientConfig.getClusterDiscoveryD2Service(),
+                clientConfig.getD2Client(),
+                clientConfig.getAuthenticationProvider()));
       case DA_VINCI_CLIENT_BASED_METADATA:
         Objects.requireNonNull(clientConfig.getDaVinciClientForMetaStore());
         return new DaVinciClientBasedMetadata(clientConfig, clientConfig.getDaVinciClientForMetaStore());

--- a/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
+++ b/clients/venice-client/src/test/java/com/linkedin/venice/fastclient/ClientConfigTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 
 import com.linkedin.r2.transport.common.Client;
+import com.linkedin.venice.authentication.jwt.ClientAuthenticationProviderToken;
 import com.linkedin.venice.client.exceptions.VeniceClientException;
 import com.linkedin.venice.client.store.AvroGenericStoreClient;
 import org.testng.annotations.Test;
@@ -92,9 +93,10 @@ public class ClientConfigTest {
 
   @Test
   public void testClientWithToken() {
+    ClientAuthenticationProviderToken testToken = ClientAuthenticationProviderToken.TOKEN("test_token");
     ClientConfig.ClientConfigBuilder clientConfigBuilder =
-        getClientConfigWithMinimumRequiredInputs().setToken("test_token");
+        getClientConfigWithMinimumRequiredInputs().setAuthenticationProvider(testToken);
 
-    assertEquals("test_token", clientConfigBuilder.build().getToken());
+    assertEquals(testToken, clientConfigBuilder.build().getAuthenticationProvider());
   }
 }

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VenicePulsarSink.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VenicePulsarSink.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.pulsar.sink;
 
+import static com.linkedin.venice.CommonConfigKeys.AUTHENTICATION_TOKEN;
 import static com.linkedin.venice.CommonConfigKeys.SSL_ENABLED;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DEPLOYMENT_ID;
 import static com.linkedin.venice.samza.VeniceSystemFactory.DOT;
@@ -245,6 +246,9 @@ public class VenicePulsarSink implements Sink<GenericObject> {
     config.put(SSL_ENABLED, "false");
     if (veniceCfg.getKafkaSaslConfig() != null && !veniceCfg.getKafkaSaslConfig().isEmpty()) {
       config.put("kafka.sasl.jaas.config", veniceCfg.getKafkaSaslConfig());
+    }
+    if (veniceCfg.getVeniceToken() != null && !veniceCfg.getVeniceToken().isEmpty()) {
+      config.put(AUTHENTICATION_TOKEN, veniceCfg.getVeniceToken());
     }
     config.put("kafka.sasl.mechanism", veniceCfg.getKafkaSaslMechanism());
     config.put("kafka.security.protocol", veniceCfg.getKafkaSecurityProtocol());

--- a/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VenicePulsarSinkConfig.java
+++ b/clients/venice-pulsar/src/main/java/com/linkedin/venice/pulsar/sink/VenicePulsarSinkConfig.java
@@ -54,6 +54,9 @@ public class VenicePulsarSinkConfig implements Serializable {
   @FieldDoc(defaultValue = "", help = "The name of the Venice store")
   private String storeName = "test-store";
 
+  @FieldDoc(defaultValue = "", help = "JWT token to authenticate")
+  private String veniceToken = "";
+
   @FieldDoc(defaultValue = "500", help = "Interval in milliseconds to flush data to Venice")
   private long flushIntervalMs = 500L;
 
@@ -110,12 +113,21 @@ public class VenicePulsarSinkConfig implements Serializable {
     return this.maxNumberUnflushedRecords;
   }
 
+  public String getVeniceToken() {
+    return veniceToken;
+  }
+
   /**
    * @return {@code this}.
    */
   @java.lang.SuppressWarnings("all")
   public VenicePulsarSinkConfig setVeniceDiscoveryUrl(final String veniceDiscoveryUrl) {
     this.veniceDiscoveryUrl = veniceDiscoveryUrl;
+    return this;
+  }
+
+  public VenicePulsarSinkConfig setVeniceToken(final String veniceToken) {
+    this.veniceToken = veniceToken;
     return this;
   }
 
@@ -202,6 +214,10 @@ public class VenicePulsarSinkConfig implements Serializable {
         ? other$veniceDiscoveryUrl != null
         : !this$veniceDiscoveryUrl.equals(other$veniceDiscoveryUrl))
       return false;
+    final java.lang.Object this$veniceToken = this.getVeniceToken();
+    final java.lang.Object other$veniceToken = other.getVeniceToken();
+    if (this$veniceToken == null ? other$veniceToken != null : !this$veniceToken.equals(other$veniceToken))
+      return false;
     final java.lang.Object this$veniceRouterUrl = this.getVeniceRouterUrl();
     final java.lang.Object other$veniceRouterUrl = other.getVeniceRouterUrl();
     if (this$veniceRouterUrl == null
@@ -248,6 +264,8 @@ public class VenicePulsarSinkConfig implements Serializable {
     result = result * PRIME + this.getMaxNumberUnflushedRecords();
     final java.lang.Object $veniceDiscoveryUrl = this.getVeniceDiscoveryUrl();
     result = result * PRIME + ($veniceDiscoveryUrl == null ? 43 : $veniceDiscoveryUrl.hashCode());
+    final java.lang.Object $veniceToken = this.getVeniceToken();
+    result = result * PRIME + ($veniceToken == null ? 43 : $veniceToken.hashCode());
     final java.lang.Object $veniceRouterUrl = this.getVeniceRouterUrl();
     result = result * PRIME + ($veniceRouterUrl == null ? 43 : $veniceRouterUrl.hashCode());
     final java.lang.Object $kafkaSaslConfig = this.getKafkaSaslConfig();
@@ -267,8 +285,8 @@ public class VenicePulsarSinkConfig implements Serializable {
     return "VeniceSinkConfig(veniceDiscoveryUrl=" + this.getVeniceDiscoveryUrl() + ", veniceRouterUrl="
         + this.getVeniceRouterUrl() + ", kafkaSaslConfig=" + this.getKafkaSaslConfig() + ", kafkaSaslMechanism="
         + this.getKafkaSaslMechanism() + ", kafkaSecurityProtocol=" + this.getKafkaSecurityProtocol() + ", storeName="
-        + this.getStoreName() + ", flushIntervalMs=" + this.getFlushIntervalMs() + ", maxNumberUnflushedRecords="
-        + this.getMaxNumberUnflushedRecords() + ")";
+        + this.getStoreName() + ", veniceToken=" + this.getVeniceToken() + ", flushIntervalMs="
+        + this.getFlushIntervalMs() + ", maxNumberUnflushedRecords=" + this.getMaxNumberUnflushedRecords() + ")";
   }
 
 }

--- a/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
+++ b/clients/venice-samza/src/main/java/com/linkedin/venice/samza/VeniceSystemFactory.java
@@ -14,6 +14,7 @@ import static com.linkedin.venice.VeniceConstants.DEFAULT_SSL_FACTORY_CLASS_NAME
 import static com.linkedin.venice.VeniceConstants.NATIVE_REPLICATION_DEFAULT_SOURCE_FABRIC;
 import static com.linkedin.venice.VeniceConstants.SYSTEM_PROPERTY_FOR_APP_RUNNING_REGION;
 
+import com.linkedin.venice.authentication.ClientAuthenticationProviderFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.Version;
 import com.linkedin.venice.security.SSLFactory;
@@ -94,11 +95,6 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
    * D2 ZK hosts for Venice Parent Cluster.
    */
   public static final String VENICE_PARENT_D2_ZK_HOSTS = "venice.parent.d2.zk.hosts";
-
-  /**
-   * JWT token authentication against Venice services.
-   */
-  public static final String VENICE_TOKEN = "venice.authentication.token";
 
   // D2 service name for local cluster
   public static final String VENICE_CHILD_CONTROLLER_D2_SERVICE = "venice.child.controller.d2.service";
@@ -365,7 +361,6 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
       LOGGER.info("{}{}: {}", prefix, VENICE_PUSH_TYPE, venicePushType);
       LOGGER.info("{}: {}", VENICE_CONTROLLER_DISCOVERY_URL, discoveryUrl.get());
       LOGGER.info("{}: {}", VENICE_ROUTER_URL, routerUrl);
-      LOGGER.info("{}: {}", VENICE_TOKEN, config.get(VENICE_TOKEN, null));
 
       VeniceSystemProducer p = new VeniceSystemProducer(
           discoveryUrl.get(),
@@ -380,7 +375,7 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
           SystemTime.INSTANCE);
       p.setRouterUrl(routerUrl);
       p.applyAdditionalWriterConfigs(config);
-      p.setToken(config.get(VENICE_TOKEN, null));
+      p.setAuthenticationProvider(ClientAuthenticationProviderFactory.build(config));
       return p;
     }
 
@@ -423,7 +418,6 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
     LOGGER.info("{}: {}", VENICE_CHILD_D2_ZK_HOSTS, localVeniceZKHosts);
     LOGGER.info("{}: {}", VENICE_PARENT_CONTROLLER_D2_SERVICE, parentControllerD2Service);
     LOGGER.info("{}: {}", VENICE_CHILD_CONTROLLER_D2_SERVICE, localControllerD2Service);
-    LOGGER.info("{}: {}", VENICE_TOKEN, config.get(VENICE_TOKEN, null));
 
     String primaryControllerColoD2ZKHost;
     String primaryControllerD2Service;
@@ -453,7 +447,7 @@ public class VeniceSystemFactory implements SystemFactory, Serializable {
         sslFactory,
         partitioners);
     systemProducer.applyAdditionalWriterConfigs(config);
-    systemProducer.setToken(config.get(VENICE_TOKEN, null));
+    systemProducer.setAuthenticationProvider(ClientAuthenticationProviderFactory.build(config));
     this.systemProducerStatues.computeIfAbsent(systemProducer, k -> Pair.create(true, false));
     return systemProducer;
   }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.client.store;
 
 import com.linkedin.d2.balancer.D2Client;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.client.store.deserialization.BatchDeserializer;
 import com.linkedin.venice.client.store.deserialization.BatchDeserializerType;
 import com.linkedin.venice.security.SSLFactory;
@@ -63,7 +64,7 @@ public class ClientConfig<T extends SpecificRecord> {
   // Test settings
   private Time time = new SystemTime();
 
-  private String token;
+  private ClientAuthenticationProvider authenticationProvider;
 
   public static ClientConfig defaultGenericClientConfig(String storeName) {
     return new ClientConfig(storeName);
@@ -109,7 +110,7 @@ public class ClientConfig<T extends SpecificRecord> {
         // Security settings
         .setHttps(config.isHttps())
         .setSslFactory(config.getSslFactory())
-        .setToken(config.getToken())
+        .setAuthenticationProvider(config.getAuthenticationProvider())
 
         .setForceClusterDiscoveryAtStartTime(config.isForceClusterDiscoveryAtStartTime())
         .setProjectionFieldValidationEnabled(config.isProjectionFieldValidationEnabled())
@@ -259,12 +260,12 @@ public class ClientConfig<T extends SpecificRecord> {
     return this;
   }
 
-  public String getToken() {
-    return token;
+  public ClientAuthenticationProvider getAuthenticationProvider() {
+    return authenticationProvider;
   }
 
-  public ClientConfig<T> setToken(String token) {
-    this.token = token;
+  public ClientConfig<T> setAuthenticationProvider(ClientAuthenticationProvider authenticationProvider) {
+    this.authenticationProvider = authenticationProvider;
     return this;
   }
 

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/ClientFactory.java
@@ -103,7 +103,7 @@ public class ClientFactory {
     String d2ServiceName = clientConfig.getD2ServiceName();
 
     if (clientConfig.getD2Client() != null) {
-      return new D2TransportClient(d2ServiceName, clientConfig.getD2Client());
+      return new D2TransportClient(d2ServiceName, clientConfig.getD2Client(), clientConfig.getAuthenticationProvider());
     }
 
     return new D2TransportClient(d2ServiceName, clientConfig);
@@ -122,9 +122,12 @@ public class ClientFactory {
         throw new VeniceClientException("Must use SSL factory method for client to communicate with https");
       }
 
-      return new HttpsTransportClient(bootstrapUrl, clientConfig.getSslFactory(), clientConfig.getToken());
+      return new HttpsTransportClient(
+          bootstrapUrl,
+          clientConfig.getSslFactory(),
+          clientConfig.getAuthenticationProvider());
     } else {
-      return new HttpTransportClient(bootstrapUrl, clientConfig.getToken());
+      return new HttpTransportClient(bootstrapUrl, clientConfig.getAuthenticationProvider());
     }
   }
 }

--- a/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
+++ b/clients/venice-thin-client/src/main/java/com/linkedin/venice/client/store/transport/HttpsTransportClient.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.client.store.transport;
 
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.security.SSLFactory;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
@@ -10,16 +11,22 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 public class HttpsTransportClient extends HttpTransportClient {
   private SSLFactory sslFactory;
 
-  public HttpsTransportClient(String routerUrl, SSLFactory sslFactory, String token) {
+  public HttpsTransportClient(
+      String routerUrl,
+      SSLFactory sslFactory,
+      ClientAuthenticationProvider authenticationProvider) {
     this(
         routerUrl,
         HttpAsyncClients.custom().setSSLStrategy(new SSLIOSessionStrategy(sslFactory.getSSLContext())).build(),
-        token);
+        authenticationProvider);
     this.sslFactory = sslFactory;
   }
 
-  public HttpsTransportClient(String routerUrl, CloseableHttpAsyncClient client, String token) {
-    super(routerUrl, client, token);
+  public HttpsTransportClient(
+      String routerUrl,
+      CloseableHttpAsyncClient client,
+      ClientAuthenticationProvider authenticationProvider) {
+    super(routerUrl, client, authenticationProvider);
     if (!routerUrl.startsWith(HTTPS)) {
       throw new VeniceException("Must use https url with HttpsTransportClient, found: " + routerUrl);
     }
@@ -31,6 +38,6 @@ public class HttpsTransportClient extends HttpTransportClient {
    */
   @Override
   public TransportClient getCopyIfNotUsableInCallback() {
-    return new HttpsTransportClient(routerUrl, sslFactory, token);
+    return new HttpsTransportClient(routerUrl, sslFactory, authenticationProvider);
   }
 }

--- a/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestTransportClient.java
+++ b/clients/venice-thin-client/src/test/java/com/linkedin/venice/client/store/TestTransportClient.java
@@ -13,6 +13,7 @@ import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.message.rest.RestResponseBuilder;
 import com.linkedin.venice.HttpConstants;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.client.store.transport.HttpTransportClient;
 import org.apache.http.HttpHeaders;
@@ -43,7 +44,7 @@ public class TestTransportClient {
   @BeforeMethod
   public void setUpTransportClient() {
     mockD2Client = mock(D2Client.class);
-    d2TransportClient = new D2TransportClient(SERVICE_NAME, mockD2Client);
+    d2TransportClient = new D2TransportClient(SERVICE_NAME, mockD2Client, ClientAuthenticationProvider.DISABLED);
 
     mockHttpClient = mock(CloseableHttpAsyncClient.class);
     httpTransportClient = new HttpTransportClient(HTTP_PREFIX + SERVICE_NAME, mockHttpClient, null);

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/authentication/ClientAuthenticationProvider.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/authentication/ClientAuthenticationProvider.java
@@ -1,0 +1,31 @@
+package com.linkedin.venice.authentication;
+
+import com.linkedin.venice.authentication.jwt.ClientAuthenticationProviderToken;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * Generic interface for client authentication providers.
+ */
+public interface ClientAuthenticationProvider extends AutoCloseable {
+  default void initialize(VeniceProperties veniceProperties) throws Exception {
+  }
+
+  Map<String, String> getHTTPAuthenticationHeaders();
+
+  @Override
+  default void close() {
+  }
+
+  /**
+   * No Authentication.
+   */
+  static ClientAuthenticationProvider DISABLED = new ClientAuthenticationProviderToken() {
+    @Override
+    public Map<String, String> getHTTPAuthenticationHeaders() {
+      return Collections.emptyMap();
+    }
+  };
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/authentication/ClientAuthenticationProviderFactory.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/authentication/ClientAuthenticationProviderFactory.java
@@ -1,0 +1,27 @@
+package com.linkedin.venice.authentication;
+
+import static com.linkedin.venice.CommonConfigKeys.AUTHENTICATION_TOKEN;
+
+import com.linkedin.venice.authentication.jwt.ClientAuthenticationProviderToken;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.util.Map;
+
+
+public final class ClientAuthenticationProviderFactory {
+  private ClientAuthenticationProviderFactory() {
+
+  }
+
+  public static ClientAuthenticationProvider build(VeniceProperties properties) {
+    return build(properties.toProperties());
+  }
+
+  public static ClientAuthenticationProvider build(Map properties) {
+    String token = properties.getOrDefault(AUTHENTICATION_TOKEN, "").toString();
+    if (token.isEmpty()) {
+      return ClientAuthenticationProvider.DISABLED;
+    } else {
+      return ClientAuthenticationProviderToken.TOKEN(token);
+    }
+  }
+}

--- a/internal/venice-client-common/src/main/java/com/linkedin/venice/authentication/jwt/ClientAuthenticationProviderToken.java
+++ b/internal/venice-client-common/src/main/java/com/linkedin/venice/authentication/jwt/ClientAuthenticationProviderToken.java
@@ -1,0 +1,50 @@
+package com.linkedin.venice.authentication.jwt;
+
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
+import com.linkedin.venice.utils.VeniceProperties;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ClientAuthenticationProviderToken implements ClientAuthenticationProvider {
+  private static final Logger log = LogManager.getLogger(ClientAuthenticationProviderToken.class);
+
+  private Map<String, String> headers;
+
+  public ClientAuthenticationProviderToken() {
+  }
+
+  public static ClientAuthenticationProviderToken TOKEN(String token) {
+    ClientAuthenticationProviderToken provider = new ClientAuthenticationProviderToken();
+    provider.headers = Collections.singletonMap("Authorization", "Bearer " + token);
+    return provider;
+  }
+
+  @Override
+  public void initialize(VeniceProperties veniceProperties) throws Exception {
+    String token = veniceProperties.getString("authentication.token", "");
+    if (token.startsWith("file://")) {
+      String path = token.substring("file://".length());
+      log.info("Reading JWT token from {}", path);
+      token = new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8);
+    }
+    if (token.isEmpty()) {
+      throw new IllegalStateException("authentication.token cannot be empty");
+    }
+    headers = Collections.singletonMap("Authorization", "Bearer " + token);
+  }
+
+  @Override
+  public Map<String, String> getHTTPAuthenticationHeaders() {
+    return headers;
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerClientFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.venice.controllerapi;
 
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.security.SSLFactory;
 import com.linkedin.venice.utils.SharedObjectFactory;
 import java.util.HashMap;
@@ -15,10 +16,10 @@ public class ControllerClientFactory {
       String clusterName,
       String discoveryUrls,
       Optional<SSLFactory> sslFactory,
-      String token) {
+      ClientAuthenticationProvider authenticationProvider) {
     final String clientIdentifier = clusterName + discoveryUrls;
     return SHARED_OBJECT_FACTORY.get(clientIdentifier, () -> {
-      ControllerClient client = new ControllerClient(clusterName, discoveryUrls, sslFactory, token);
+      ControllerClient client = new ControllerClient(clusterName, discoveryUrls, sslFactory, authenticationProvider);
       CONTROLLER_CLIENT_TO_IDENTIFIER_MAP.put(client, clientIdentifier);
       return client;
     }, client -> {

--- a/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
+++ b/internal/venice-common/src/main/java/com/linkedin/venice/controllerapi/ControllerTransport.java
@@ -2,6 +2,7 @@ package com.linkedin.venice.controllerapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.venice.HttpMethod;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.exceptions.ErrorType;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.exceptions.VeniceHttpException;
@@ -53,14 +54,14 @@ public class ControllerTransport implements AutoCloseable {
   private final CloseableHttpAsyncClient httpClient;
   private Map<String, String> additionalHeaders = new ConcurrentHashMap<>();
 
-  public ControllerTransport(Optional<SSLFactory> sslFactory, String token) {
+  public ControllerTransport(Optional<SSLFactory> sslFactory, ClientAuthenticationProvider authenticationProvider) {
     this.httpClient = HttpAsyncClients.custom()
         .setDefaultRequestConfig(this.REQUEST_CONFIG)
         .setSSLStrategy(sslFactory.isPresent() ? new SSLIOSessionStrategy(sslFactory.get().getSSLContext()) : null)
         .build();
     this.httpClient.start();
-    if (token != null && !token.isEmpty()) {
-      this.additionalHeaders.put("Authorization", "Bearer " + token);
+    if (authenticationProvider != null) {
+      this.additionalHeaders.putAll(authenticationProvider.getHTTPAuthenticationHeaders());
     }
   }
 

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestJWTAuthenticationEndToEnd.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/controller/TestJWTAuthenticationEndToEnd.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authentication.jwt.ClientAuthenticationProviderToken;
 import com.linkedin.venice.authentication.jwt.TokenAuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.authorization.SimpleAuthorizerService;
@@ -76,8 +77,11 @@ public class TestJWTAuthenticationEndToEnd {
       assertNull(store);
     }
 
-    try (ControllerClient controllerClient = ControllerClient
-        .constructClusterControllerClient(clusterName, venice.getAllControllersURLs(), Optional.empty(), token);) {
+    try (ControllerClient controllerClient = ControllerClient.constructClusterControllerClient(
+        clusterName,
+        venice.getAllControllersURLs(),
+        Optional.empty(),
+        ClientAuthenticationProviderToken.TOKEN(token));) {
       controllerClient.createNewStore(storeName, "dev", schema, schema);
       Store store = venice.getLeaderVeniceController().getVeniceAdmin().getStore(clusterName, storeName);
       assertNotNull(store);

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataIntegrationTest.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/fastclient/meta/RequestBasedMetadataIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.testng.Assert.*;
 import com.linkedin.d2.balancer.D2Client;
 import com.linkedin.r2.transport.common.Client;
 import com.linkedin.venice.D2.D2ClientUtils;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.client.store.transport.D2TransportClient;
 import com.linkedin.venice.compression.CompressionStrategy;
 import com.linkedin.venice.compression.VeniceCompressor;
@@ -79,7 +80,10 @@ public class RequestBasedMetadataIntegrationTest {
 
     requestBasedMetadata = new RequestBasedMetadata(
         clientConfig,
-        new D2TransportClient(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME, d2Client));
+        new D2TransportClient(
+            VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+            d2Client,
+            ClientAuthenticationProvider.DISABLED));
     requestBasedMetadata.start();
   }
 
@@ -139,7 +143,10 @@ public class RequestBasedMetadataIntegrationTest {
 
     RequestBasedMetadata zstdRequestBasedMetadata = new RequestBasedMetadata(
         zstdClientConfig,
-        new D2TransportClient(VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME, d2Client));
+        new D2TransportClient(
+            VeniceRouterWrapper.CLUSTER_DISCOVERY_D2_SERVICE_NAME,
+            d2Client,
+            ClientAuthenticationProvider.DISABLED));
     zstdRequestBasedMetadata.start();
 
     VeniceRouterWrapper routerWrapper = veniceCluster.getRandomVeniceRouter();

--- a/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterWithTokenAuthentication.java
+++ b/internal/venice-test-common/src/integrationtest/java/com/linkedin/venice/router/TestRouterWithTokenAuthentication.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 
 import com.linkedin.venice.authentication.AuthenticationService;
+import com.linkedin.venice.authentication.jwt.ClientAuthenticationProviderToken;
 import com.linkedin.venice.authentication.jwt.TokenAuthenticationService;
 import com.linkedin.venice.authorization.AuthorizerService;
 import com.linkedin.venice.authorization.SimpleAuthorizerService;
@@ -87,7 +88,7 @@ public class TestRouterWithTokenAuthentication {
     try (AvroGenericStoreClient<Object, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
             .setVeniceURL("http://" + routers.get(0).getAddress())
-            .setToken("xxx"))) {
+            .setAuthenticationProvider(ClientAuthenticationProviderToken.TOKEN("xxx")))) {
       storeClient.get("myKey").get();
     } catch (ExecutionException ok) {
       VeniceClientHttpException veniceClientHttpException = (VeniceClientHttpException) ok.getCause();
@@ -98,7 +99,9 @@ public class TestRouterWithTokenAuthentication {
     try (AvroGenericStoreClient<Object, Object> storeClient = ClientFactory.getAndStartGenericAvroClient(
         ClientConfig.defaultGenericClientConfig(storeName)
             .setVeniceURL("http://" + routers.get(0).getAddress())
-            .setToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.DBjI5MJuVyCa6oncrP5eEP329Pmixk6SX4UG-HS0P7g"))) {
+            .setAuthenticationProvider(
+                ClientAuthenticationProviderToken
+                    .TOKEN("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.DBjI5MJuVyCa6oncrP5eEP329Pmixk6SX4UG-HS0P7g")))) {
       assertNull(storeClient.get("myKey").get());
     }
   }

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerClusterConfig.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.controller;
 
-import static com.linkedin.venice.CommonConfigKeys.AUTHENTICATION_TOKEN;
 import static com.linkedin.venice.CommonConfigKeys.SSL_FACTORY_CLASS_NAME;
 import static com.linkedin.venice.ConfigKeys.ADMIN_TOPIC_REPLICATION_FACTOR;
 import static com.linkedin.venice.ConfigKeys.CHILD_CLUSTER_ALLOWLIST;
@@ -76,6 +75,8 @@ import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_MIN_LOG_COMPA
 import static com.linkedin.venice.kafka.TopicManager.DEFAULT_KAFKA_REPLICATION_FACTOR;
 
 import com.linkedin.venice.SSLConfig;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
+import com.linkedin.venice.authentication.ClientAuthenticationProviderFactory;
 import com.linkedin.venice.exceptions.ConfigurationException;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.meta.OfflinePushStrategy;
@@ -131,7 +132,7 @@ public class VeniceControllerClusterConfig {
   // SSL related config
   Optional<SSLConfig> sslConfig;
   private String sslFactoryClassName;
-  private String token;
+  private ClientAuthenticationProvider authenticationProvider;
   private int refreshAttemptsForZkReconnect;
   private long refreshIntervalForZkReconnectInMs;
   private boolean enableOfflinePushSSLAllowlist;
@@ -386,7 +387,7 @@ public class VeniceControllerClusterConfig {
       sslConfig = Optional.empty();
     }
     sslFactoryClassName = props.getString(SSL_FACTORY_CLASS_NAME, DEFAULT_SSL_FACTORY_CLASS_NAME);
-    token = props.getString(AUTHENTICATION_TOKEN, "");
+    authenticationProvider = ClientAuthenticationProviderFactory.build(props);
     refreshAttemptsForZkReconnect = props.getInt(REFRESH_ATTEMPTS_FOR_ZK_RECONNECT, 3);
     refreshIntervalForZkReconnectInMs =
         props.getLong(REFRESH_INTERVAL_FOR_ZK_RECONNECT_MS, java.util.concurrent.TimeUnit.SECONDS.toMillis(10));
@@ -570,8 +571,8 @@ public class VeniceControllerClusterConfig {
     return sslFactoryClassName;
   }
 
-  public String getToken() {
-    return token;
+  public ClientAuthenticationProvider getAuthenticationProvider() {
+    return authenticationProvider;
   }
 
   public int getRefreshAttemptsForZkReconnect() {

--- a/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
+++ b/services/venice-controller/src/main/java/com/linkedin/venice/controller/VeniceControllerMultiClusterConfig.java
@@ -1,6 +1,7 @@
 package com.linkedin.venice.controller;
 
 import com.linkedin.venice.SSLConfig;
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
 import com.linkedin.venice.controllerapi.ControllerRoute;
 import com.linkedin.venice.exceptions.VeniceNoClusterException;
 import com.linkedin.venice.utils.VeniceProperties;
@@ -101,8 +102,8 @@ public class VeniceControllerMultiClusterConfig {
     return getCommonConfig().getSslFactoryClassName();
   }
 
-  public String getToken() {
-    return getCommonConfig().getToken();
+  public ClientAuthenticationProvider getAuthenticationProvider() {
+    return getCommonConfig().getAuthenticationProvider();
   }
 
   public boolean isDisableParentRequestTopicForStreamPushes() {

--- a/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
+++ b/services/venice-router/src/main/java/com/linkedin/venice/router/VeniceRouterConfig.java
@@ -1,6 +1,5 @@
 package com.linkedin.venice.router;
 
-import static com.linkedin.venice.CommonConfigKeys.AUTHENTICATION_TOKEN;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_NAME;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_D2;
 import static com.linkedin.venice.ConfigKeys.CLUSTER_TO_SERVER_D2;
@@ -97,6 +96,8 @@ import static com.linkedin.venice.helix.HelixInstanceConfigRepository.ZONE_FIELD
 import static com.linkedin.venice.router.api.VeniceMultiKeyRoutingStrategy.LEAST_LOADED_ROUTING;
 import static com.linkedin.venice.router.api.routing.helix.HelixGroupSelectionStrategyEnum.LEAST_LOADED;
 
+import com.linkedin.venice.authentication.ClientAuthenticationProvider;
+import com.linkedin.venice.authentication.ClientAuthenticationProviderFactory;
 import com.linkedin.venice.exceptions.VeniceException;
 import com.linkedin.venice.router.api.VeniceMultiKeyRoutingStrategy;
 import com.linkedin.venice.router.api.routing.helix.HelixGroupSelectionStrategyEnum;
@@ -215,7 +216,7 @@ public class VeniceRouterConfig {
   /**
    * Authentication token for connections to other Venice components
    */
-  private String token;
+  private ClientAuthenticationProvider authenticationProvider;
 
   public VeniceRouterConfig(VeniceProperties props) {
     try {
@@ -394,7 +395,7 @@ public class VeniceRouterConfig {
     perRouterStorageNodeThrottlerEnabled = props.getBoolean(ROUTER_PER_STORAGE_NODE_THROTTLER_ENABLED, true);
     perStoreRouterQuotaBuffer = props.getDouble(ROUTER_PER_STORE_ROUTER_QUOTA_BUFFER, 1.5);
     httpClientOpensslEnabled = props.getBoolean(ROUTER_HTTP_CLIENT_OPENSSL_ENABLED, true);
-    token = props.getString(AUTHENTICATION_TOKEN, "");
+    authenticationProvider = ClientAuthenticationProviderFactory.build(props);
   }
 
   public double getPerStoreRouterQuotaBuffer() {
@@ -842,7 +843,7 @@ public class VeniceRouterConfig {
     return httpClientOpensslEnabled;
   }
 
-  public String getToken() {
-    return token;
+  public ClientAuthenticationProvider getAuthenticationProvider() {
+    return authenticationProvider;
   }
 }

--- a/tests/venice-pulsar-test/src/pulsarintegrationtest/java/com/linkedin/venice/pulsar/sink/PulsarVeniceSinkTest.java
+++ b/tests/venice-pulsar-test/src/pulsarintegrationtest/java/com/linkedin/venice/pulsar/sink/PulsarVeniceSinkTest.java
@@ -162,8 +162,6 @@ public class PulsarVeniceSinkTest {
     createTopics();
 
     LOGGER.info("Starting up Pulsar Venice Sink");
-    String token =
-        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdXBlcnVzZXIifQ.JQpDWJ9oHD743ZyuIw55Qp0bb8xzP6gK0KIWRniF2WnJB1m3v5MsrpfMlmRIlFc3-htWRAFHCc4E0ipj7JU8HjBqLIvVErRseRG-UTM1EprVkj0mk37jXV3ef7gER0KHn9CUKEQPfmTACeKlQ2oV4_qPAZ6HiEt51vzANfZH24vLCIjiOG77Z4s_w2sfgpiodRmhBLFOg_qnQTfGs7TBDWgu4DRoJ6CYZSEcp8q7j8xp_zNVIFGTRjWskocUvedHS9ZsCGZjzuPvRPp19B0VvAjEjtwpa6j7Khvjf4imjp2QHDnZwpCIEp4DSicwM48F5q4k722IdiyTTsVBWy8Cyg";
 
     String sinkConfig = "{\"veniceDiscoveryUrl\":\"" + veniceControllerUrl + "\"," + "\"veniceRouterUrl\":\""
         + veniceRouterUrl + "\"," + "\"storeName\":\"t1_n1_s1\"}";


### PR DESCRIPTION
Remove all hardcoded "token" parameters and field and abstract over a generic provider.
This is required in order to implement token refresh (for OAuth2) and also loading the token from files

Changes:
- Introduce a new API ClientAuthenticationProvider (lifecycle is still to be defined)
- Add ability to read the JWT from a file
